### PR TITLE
Adapt to the latest WebMCP spec

### DIFF
--- a/examples/shopify_storefront.js
+++ b/examples/shopify_storefront.js
@@ -146,15 +146,19 @@ function registerShopifyTool(toolSchema, mcpEndpoint) {
     inputSchema: toolSchema.inputSchema || { type: 'object', properties: {} },
 
     // Create an execute function that proxies to MCP
+    // Per WebMCP spec: execute receives (args, agent)
     execute: createExecutor(toolSchema.name, mcpEndpoint)
   };
 
-  // Register with the agent
-  if (window.agent && typeof window.agent.registerTool === 'function') {
-    window.agent.registerTool(tool);
+  // Register with modelContext (per WebMCP spec)
+  // Falls back to window.agent for backward compat
+  const modelContext = ('modelContext' in navigator) ? navigator.modelContext : window.agent;
+  
+  if (modelContext && typeof modelContext.registerTool === 'function') {
+    modelContext.registerTool(tool);
     console.log(`[Shopify Bootstrap] ✅ Successfully registered: ${toolName}`);
   } else {
-    throw new Error('window.agent.registerTool not available');
+    throw new Error('navigator.modelContext.registerTool not available');
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-sidebar-extension",
-  "version": "0.4.7",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-sidebar-extension",
-      "version": "0.4.7",
+      "version": "0.6.0",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "^2.0.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sidebar-extension",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Chrome extension AI sidebar with LLM providers and MCP support",
   "private": true,
   "type": "module",

--- a/src/content-scripts/webmcp-polyfill.js
+++ b/src/content-scripts/webmcp-polyfill.js
@@ -2,12 +2,31 @@
  * WebMCP Polyfill - Complete implementation of WebMCP API
  * Provides tool registration and invocation capabilities for web agents
  *
- * Usage: Include this script before any code that uses window.agent
+ * Aligns with WebMCP proposed spec:
+ * https://github.com/webmachinelearning/webmcp/blob/main/docs/proposal.md
+ *
+ * API: window.navigator.modelContext
+ * Backward compat: window.agent (alias)
+ *
+ * Chrome Canary native support:
+ * - navigator.modelContextTesting (agent-side: listTools, executeTool, registerToolsChangedCallback)
+ * - navigator.modelContext (page-side: provideContext, registerTool) - when available
  */
 (function () {
   'use strict';
 
-  if ('agent' in window) {
+  // Guard: already initialized (either by us or native browser support)
+  if ('modelContext' in navigator) {
+    console.log('[WebMCP] Native navigator.modelContext detected, skipping polyfill');
+    // Still set up window.agent alias for backward compat if not present
+    if (!('agent' in window)) {
+      Object.defineProperty(window, 'agent', {
+        value: navigator.modelContext,
+        writable: false,
+        configurable: false,
+        enumerable: true
+      });
+    }
     return;
   }
 
@@ -189,93 +208,251 @@
     };
   }
 
-  function createAgent() {
-    const tools = new Map();
-    const events = createEventTarget();
-
-    function validateAndNormalizeTool(tool) {
-      if (!tool || typeof tool !== 'object') {
-        throw new ValidationError('Tool must be an object');
+  /**
+   * Create an agent context object to pass to tool execute functions
+   * Per WebMCP spec, this provides requestUserInteraction() API
+   */
+  function createAgentContext() {
+    return {
+      /**
+       * Request user interaction during tool execution
+       * Allows tools to prompt for confirmation, input, etc.
+       *
+       * @param {Function} interactionFn - Async function that performs UI interaction
+       * @returns {Promise<any>} - Result of the interaction function
+       *
+       * Example:
+       *   const confirmed = await agent.requestUserInteraction(async () => {
+       *     return confirm('Proceed with purchase?');
+       *   });
+       */
+      async requestUserInteraction(interactionFn) {
+        if (typeof interactionFn !== 'function') {
+          throw new ValidationError('requestUserInteraction requires a function');
+        }
+        // Execute the interaction function - it handles its own UI
+        return await interactionFn();
       }
-      const { name, description, inputSchema, execute } = tool;
-      if (!name || typeof name !== 'string') throw new ValidationError('Tool must have a string name');
-      if (!description || typeof description !== 'string') throw new ValidationError('Tool must have a string description');
-      if (typeof execute !== 'function') throw new ValidationError('Tool must have an execute function');
-      return {
-        name,
-        description,
-        inputSchema: inputSchema || { type: 'object', properties: {} },
-        execute
-      };
-    }
-
-    const agent = {
-      // Replace entire tool set
-      provideContext(context) {
-        if (!context || !context.tools || !Array.isArray(context.tools)) {
-          throw new ValidationError('Context must have a tools array');
-        }
-        tools.clear();
-        for (const raw of context.tools) {
-          const tool = validateAndNormalizeTool(raw);
-          if (tools.has(tool.name)) {
-            throw new ValidationError(`Duplicate tool name: ${tool.name}`);
-          }
-          tools.set(tool.name, tool);
-        }
-        // Notify listeners
-        queueMicrotask(() => events.dispatchEvent({ type: 'tools/listChanged' }));
-      },
-
-      // Append a single tool
-      registerTool(rawTool) {
-        const tool = validateAndNormalizeTool(rawTool);
-        if (tools.has(tool.name)) {
-          // Allow replacement for hot reload
-          console.warn(`[WebMCP] Replacing existing tool: ${tool.name}`);
-        }
-        tools.set(tool.name, tool);
-        queueMicrotask(() => events.dispatchEvent({ type: 'tools/listChanged' }));
-      },
-
-      // Invoke a tool
-      async callTool(toolName, params = {}) {
-        if (!tools.has(toolName)) {
-          throw new ToolNotFoundError(toolName);
-        }
-        const tool = tools.get(toolName);
-        try {
-          validateParams(params, tool.inputSchema);
-          return await Promise.resolve(tool.execute(params));
-        } catch (err) {
-          if (err instanceof ValidationError || err instanceof ExecutionError) throw err;
-          throw new ExecutionError(`Tool '${toolName}' execution failed: ${err && err.message ? err.message : String(err)}`, err);
-        }
-      },
-
-      // Discover tools
-      listTools() {
-        return Array.from(tools.values()).map(({ name, description, inputSchema }) => ({
-          name, description, inputSchema
-        }));
-      },
-
-      // Events
-      addEventListener: events.addEventListener.bind(events),
-      removeEventListener: events.removeEventListener.bind(events)
     };
-
-    return agent;
   }
 
-  // Initialize the agent
-  window.agent = createAgent();
-  window.agent.errors = {
+  // Shared state between page-side (modelContext) and agent-side (modelContextTesting) APIs
+  const tools = new Map();
+  const events = createEventTarget();
+  const toolsChangedCallbacks = [];
+
+  // Forward internal events to toolsChangedCallbacks
+  events.addEventListener('tools/listChanged', () => {
+    for (const callback of toolsChangedCallbacks) {
+      try {
+        callback();
+      } catch (err) {
+        console.error('[WebMCP] Error in toolsChangedCallback:', err);
+      }
+    }
+  });
+
+  function validateAndNormalizeTool(tool) {
+    if (!tool || typeof tool !== 'object') {
+      throw new ValidationError('Tool must be an object');
+    }
+    const { name, description, inputSchema, execute } = tool;
+    if (!name || typeof name !== 'string') throw new ValidationError('Tool must have a string name');
+    if (!description || typeof description !== 'string') throw new ValidationError('Tool must have a string description');
+    if (typeof execute !== 'function') throw new ValidationError('Tool must have an execute function');
+    return {
+      name,
+      description,
+      inputSchema: inputSchema || { type: 'object', properties: {} },
+      execute
+    };
+  }
+
+  /**
+   * Internal function to execute a tool
+   * Used by both modelContext.callTool (legacy) and modelContextTesting.executeTool
+   */
+  async function executeToolInternal(toolName, params = {}) {
+    if (!tools.has(toolName)) {
+      throw new ToolNotFoundError(toolName);
+    }
+    const tool = tools.get(toolName);
+    try {
+      validateParams(params, tool.inputSchema);
+      // Create agent context for this tool execution
+      const agentContext = createAgentContext();
+      // Per WebMCP spec: execute(params, agent)
+      return await Promise.resolve(tool.execute(params, agentContext));
+    } catch (err) {
+      if (err instanceof ValidationError || err instanceof ExecutionError) throw err;
+      throw new ExecutionError(`Tool '${toolName}' execution failed: ${err && err.message ? err.message : String(err)}`, err);
+    }
+  }
+
+  /**
+   * Internal function to list tools
+   * Used by both APIs
+   */
+  function listToolsInternal() {
+    return Array.from(tools.values()).map(({ name, description, inputSchema }) => ({
+      name, description, inputSchema
+    }));
+  }
+
+  /**
+   * PAGE-SIDE API: navigator.modelContext
+   * For pages to register tools with the agent
+   */
+  const modelContext = {
+    /**
+     * Replace entire tool set (per WebMCP spec)
+     * Clears any pre-existing tools before registering new ones
+     */
+    provideContext(context) {
+      if (!context || !context.tools || !Array.isArray(context.tools)) {
+        throw new ValidationError('Context must have a tools array');
+      }
+      tools.clear();
+      for (const raw of context.tools) {
+        const tool = validateAndNormalizeTool(raw);
+        if (tools.has(tool.name)) {
+          throw new ValidationError(`Duplicate tool name: ${tool.name}`);
+        }
+        tools.set(tool.name, tool);
+      }
+      // Notify listeners
+      queueMicrotask(() => events.dispatchEvent({ type: 'tools/listChanged' }));
+    },
+
+    /**
+     * Register a single tool (per WebMCP spec)
+     * Adds to existing tools without clearing
+     */
+    registerTool(rawTool) {
+      const tool = validateAndNormalizeTool(rawTool);
+      if (tools.has(tool.name)) {
+        // Allow replacement for hot reload
+        console.warn(`[WebMCP] Replacing existing tool: ${tool.name}`);
+      }
+      tools.set(tool.name, tool);
+      queueMicrotask(() => events.dispatchEvent({ type: 'tools/listChanged' }));
+    },
+
+    /**
+     * Unregister a tool by name (per WebMCP spec)
+     */
+    unregisterTool(toolName) {
+      if (typeof toolName !== 'string') {
+        throw new ValidationError('Tool name must be a string');
+      }
+      const existed = tools.delete(toolName);
+      if (existed) {
+        queueMicrotask(() => events.dispatchEvent({ type: 'tools/listChanged' }));
+      }
+      return existed;
+    },
+
+    /**
+     * Clear all tools (per Chrome's WebMCP implementation)
+     */
+    clearContext() {
+      const hadTools = tools.size > 0;
+      tools.clear();
+      if (hadTools) {
+        queueMicrotask(() => events.dispatchEvent({ type: 'tools/listChanged' }));
+      }
+    }
+  };
+
+  /**
+   * AGENT-SIDE API: navigator.modelContextTesting
+   * For agents to discover and call tools registered by pages
+   */
+  const modelContextTesting = {
+    /**
+     * List all registered tools (agent-side)
+     * Returns tool descriptors without execute functions
+     */
+    listTools() {
+      return listToolsInternal();
+    },
+
+    /**
+     * Execute a tool by name (agent-side)
+     * Chrome's native API expects args as JSON string
+     */
+    async executeTool(name, args = '{}') {
+      // Parse args if it's a JSON string (Chrome's native format)
+      const parsedArgs = typeof args === 'string' ? JSON.parse(args) : args;
+      return executeToolInternal(name, parsedArgs);
+    },
+
+    /**
+     * Register a callback for when tools change (agent-side)
+     * Chrome's native API uses this pattern instead of addEventListener
+     */
+    registerToolsChangedCallback(callback) {
+      if (typeof callback !== 'function') {
+        throw new TypeError('Callback must be a function');
+      }
+      toolsChangedCallbacks.push(callback);
+    }
+  };
+
+  // Make modelContextTesting look like Chrome's native implementation
+  Object.defineProperty(modelContextTesting, Symbol.toStringTag, {
+    value: 'ModelContextTesting',
+    configurable: true
+  });
+
+  // Define navigator.modelContext (page-side API)
+  Object.defineProperty(navigator, 'modelContext', {
+    value: modelContext,
+    writable: false,
+    configurable: false,
+    enumerable: true
+  });
+
+  // Define navigator.modelContextTesting (agent-side API)
+  Object.defineProperty(navigator, 'modelContextTesting', {
+    value: modelContextTesting,
+    writable: false,
+    configurable: false,
+    enumerable: true
+  });
+
+  // Backward compatibility: window.agent combines both APIs for legacy scripts
+  const agentCompat = {
+    // Page-side methods
+    provideContext: modelContext.provideContext.bind(modelContext),
+    registerTool: modelContext.registerTool.bind(modelContext),
+    unregisterTool: modelContext.unregisterTool.bind(modelContext),
+    clearContext: modelContext.clearContext.bind(modelContext),
+    // Agent-side methods (legacy support)
+    listTools: modelContextTesting.listTools.bind(modelContextTesting),
+    callTool: (name, args) => executeToolInternal(name, args), // Direct call, not JSON string
+    // Legacy event API
+    addEventListener: events.addEventListener.bind(events),
+    removeEventListener: events.removeEventListener.bind(events)
+  };
+
+  Object.defineProperty(window, 'agent', {
+    value: agentCompat,
+    writable: false,
+    configurable: false,
+    enumerable: true
+  });
+
+  // Expose error classes on all APIs for consumers
+  const errorClasses = {
     WebMCPError,
     ToolNotFoundError,
     ValidationError,
     ExecutionError
   };
+  modelContext.errors = errorClasses;
+  modelContextTesting.errors = errorClasses;
+  window.agent.errors = errorClasses;
 
   // Create Trusted Types policy for user script injection
   if (typeof trustedTypes !== 'undefined') {
@@ -297,4 +474,6 @@
       console.warn('[WebMCP] User scripts may not work on this site due to Trusted Types');
     }
   }
+
+  console.log('[WebMCP] Polyfill ready: navigator.modelContext, navigator.modelContextTesting (also: window.agent)');
 })();

--- a/src/lib/ajv-csp-safe.js
+++ b/src/lib/ajv-csp-safe.js
@@ -1,0 +1,138 @@
+/**
+ * CSP-safe Ajv shim for Chrome extensions
+ * 
+ * Ajv uses new Function() for performance, which violates Chrome extension CSP.
+ * This shim provides a minimal implementation that validates without eval.
+ * 
+ * Trade-off: Less thorough validation, but works in extension context.
+ */
+
+class AjvCSPSafe {
+  constructor(options = {}) {
+    this.schemas = new Map();
+    this.options = options;
+  }
+
+  compile(schema) {
+    // Return a validator function that does basic type checking
+    // without using eval/Function
+    return (data) => {
+      const errors = [];
+      
+      if (!this._validate(schema, data, '', errors)) {
+        const validator = () => false;
+        validator.errors = errors;
+        return false;
+      }
+      
+      return true;
+    };
+  }
+
+  _validate(schema, data, path, errors) {
+    if (!schema || typeof schema !== 'object') {
+      return true; // No schema = valid
+    }
+
+    // Handle type checking
+    if (schema.type) {
+      const types = Array.isArray(schema.type) ? schema.type : [schema.type];
+      const actualType = this._getType(data);
+      
+      if (!types.includes(actualType) && !(actualType === 'integer' && types.includes('number'))) {
+        errors.push({
+          instancePath: path,
+          schemaPath: `${path}/type`,
+          keyword: 'type',
+          params: { type: schema.type },
+          message: `must be ${schema.type}`
+        });
+        return false;
+      }
+    }
+
+    // Handle required properties
+    if (schema.required && Array.isArray(schema.required) && typeof data === 'object' && data !== null) {
+      for (const prop of schema.required) {
+        if (!(prop in data)) {
+          errors.push({
+            instancePath: path,
+            schemaPath: `${path}/required`,
+            keyword: 'required',
+            params: { missingProperty: prop },
+            message: `must have required property '${prop}'`
+          });
+          return false;
+        }
+      }
+    }
+
+    // Handle properties (recursive)
+    if (schema.properties && typeof data === 'object' && data !== null) {
+      for (const [key, propSchema] of Object.entries(schema.properties)) {
+        if (key in data) {
+          if (!this._validate(propSchema, data[key], `${path}/${key}`, errors)) {
+            return false;
+          }
+        }
+      }
+    }
+
+    // Handle items (arrays)
+    if (schema.items && Array.isArray(data)) {
+      for (let i = 0; i < data.length; i++) {
+        if (!this._validate(schema.items, data[i], `${path}/${i}`, errors)) {
+          return false;
+        }
+      }
+    }
+
+    // Handle enum
+    if (schema.enum && !schema.enum.includes(data)) {
+      errors.push({
+        instancePath: path,
+        schemaPath: `${path}/enum`,
+        keyword: 'enum',
+        params: { allowedValues: schema.enum },
+        message: `must be one of: ${schema.enum.join(', ')}`
+      });
+      return false;
+    }
+
+    return true;
+  }
+
+  _getType(value) {
+    if (value === null) return 'null';
+    if (Array.isArray(value)) return 'array';
+    if (typeof value === 'number') {
+      return Number.isInteger(value) ? 'integer' : 'number';
+    }
+    return typeof value;
+  }
+
+  addSchema(schema, key) {
+    this.schemas.set(key || schema.$id, schema);
+    return this;
+  }
+
+  getSchema(key) {
+    const schema = this.schemas.get(key);
+    return schema ? this.compile(schema) : undefined;
+  }
+
+  validate(schemaOrRef, data) {
+    const schema = typeof schemaOrRef === 'string' 
+      ? this.schemas.get(schemaOrRef) 
+      : schemaOrRef;
+    
+    if (!schema) return true;
+    
+    const validator = this.compile(schema);
+    return validator(data);
+  }
+}
+
+// Export as default (matching Ajv's export)
+export default AjvCSPSafe;
+

--- a/src/lib/webmcp/lifecycle.ts
+++ b/src/lib/webmcp/lifecycle.ts
@@ -226,8 +226,22 @@ export class TabManager {
    * Update tool registry for a tab
    */
   private updateToolRegistry(tabId: number, params: ToolsListChangedParams): void {
+    // Parse inputSchema if it's a JSON string (Chrome's native API returns it as string)
+    const normalizedTools = (params.tools || []).map((tool) => {
+      let inputSchema = tool.inputSchema;
+      if (typeof inputSchema === 'string') {
+        try {
+          inputSchema = JSON.parse(inputSchema);
+          log.debug(`[WebMCP Lifecycle] Parsed inputSchema for tool "${tool.name}"`);
+        } catch (e) {
+          log.warn(`[WebMCP Lifecycle] Failed to parse inputSchema for tool "${tool.name}":`, e);
+        }
+      }
+      return { ...tool, inputSchema };
+    });
+
     const registry: ToolRegistry = {
-      tools: params.tools || [],
+      tools: normalizedTools,
       origin: params.origin || '',
       timestamp: params.timestamp ?? Date.now(),
     };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,6 +21,9 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
       '@lib': path.resolve(__dirname, './src/lib'),
       '@types': path.resolve(__dirname, './src/types'),
+      // Use CSP-safe Ajv shim - real Ajv uses new Function() which violates extension CSP
+      // Also fixes ESM import issue (ajv doesn't have default export in ESM)
+      ajv: path.resolve(__dirname, 'src/lib/ajv-csp-safe.js'),
     },
   },
   build: {
@@ -72,6 +75,6 @@ export default defineConfig({
   },
   // Chrome extension specific optimizations
   optimizeDeps: {
-    exclude: ['@modelcontextprotocol/sdk'],
+    // With our CSP-safe ajv shim, we can pre-bundle normally
   },
 });


### PR DESCRIPTION
## Align WebMCP polyfill with Chrome Canary's native implementation

Tested in 146.0.7652.0 canary

- **Separated page-side and agent-side APIs** to match Chrome's WebMCP spec: `navigator.modelContext` for pages to register tools (`registerTool`, `unregisterTool`, `provideContext`, `clearContext`) and `navigator.modelContextTesting` for agents to discover/execute tools (`listTools`, `executeTool`, `registerToolsChangedCallback`)

- **Fixed Chrome native API compatibility**: `executeTool()` now accepts args as JSON string (Chrome's format), and `inputSchema` returned from `listTools()` is automatically parsed from JSON string to object in `lifecycle.ts`

- **Added CSP-safe Ajv shim** (`src/lib/ajv-csp-safe.js`) to replace real Ajv which uses `new Function()` that violates Chrome extension CSP, also fixing the ESM default export issue

- **Updated page-bridge.js** to use spec-aligned method names (`executeTool`, `registerToolsChangedCallback`) and removed dead fallback code that referenced non-existent methods on the separated APIs

- **Maintained backward compatibility** via `window.agent` which combines both page-side and agent-side methods for existing scripts, while new code should use the separated `modelContext`/`modelContextTesting` APIs