### PR TITLE
Handle ontoolchange alongside registerToolsChangedCallback

### DIFF
--- a/src/content-scripts/page-bridge.js
+++ b/src/content-scripts/page-bridge.js
@@ -38,12 +38,23 @@
   function getAgentAPI() {
     // Use modelContextTesting (agent-side API) - either native Chrome or our polyfill
     if ('modelContextTesting' in navigator) {
+      const mct = navigator.modelContextTesting;
+      const isNative = !Object.prototype.hasOwnProperty.call(mct, 'errors'); // Native won't have our errors property
       return {
-        native: !Object.prototype.hasOwnProperty.call(navigator.modelContextTesting, 'errors'), // Native won't have our errors property
-        listTools: () => navigator.modelContextTesting.listTools(),
+        native: isNative,
+        listTools: () => mct.listTools(),
         // executeTool expects args as JSON string
-        executeTool: (name, args) => navigator.modelContextTesting.executeTool(name, JSON.stringify(args)),
-        registerToolsChangedCallback: (callback) => navigator.modelContextTesting.registerToolsChangedCallback(callback)
+        executeTool: (name, args) => mct.executeTool(name, JSON.stringify(args)),
+        registerToolsChangedCallback: (callback) => {
+          // Chrome Canary (M147+) switched from registerToolsChangedCallback to ontoolchange
+          if (typeof mct.registerToolsChangedCallback === 'function') {
+            mct.registerToolsChangedCallback(callback);
+          } else if ('ontoolchange' in mct) {
+            mct.ontoolchange = callback;
+          } else {
+            console.warn('[WebMCP Bridge] No tools-changed callback mechanism found on modelContextTesting');
+          }
+        }
       };
     }
     // Legacy fallback: window.agent (backward compat API)

--- a/src/content-scripts/webmcp-polyfill.js
+++ b/src/content-scripts/webmcp-polyfill.js
@@ -407,7 +407,26 @@
         throw new TypeError('Callback must be a function');
       }
       toolsChangedCallbacks.push(callback);
-    }
+    },
+    // Chrome Canary (M147+) uses ontoolchange instead of registerToolsChangedCallback
+    set ontoolchange(callback) {
+      if (callback !== null && typeof callback !== 'function') {
+        throw new TypeError('ontoolchange must be a function or null');
+      }
+      // Replace any previously set ontoolchange handler
+      if (modelContextTesting._ontoolchangeHandler) {
+        const idx = toolsChangedCallbacks.indexOf(modelContextTesting._ontoolchangeHandler);
+        if (idx !== -1) toolsChangedCallbacks.splice(idx, 1);
+      }
+      modelContextTesting._ontoolchangeHandler = callback;
+      if (callback) {
+        toolsChangedCallbacks.push(callback);
+      }
+    },
+    get ontoolchange() {
+      return modelContextTesting._ontoolchangeHandler || null;
+    },
+    _ontoolchangeHandler: null
   };
 
   // Make modelContextTesting look like Chrome's native implementation

--- a/tests/webmcp-polyfill.test.ts
+++ b/tests/webmcp-polyfill.test.ts
@@ -54,6 +54,8 @@ describe('WebMCP Polyfill - API Location', () => {
     expect(typeof (window as any).navigator.modelContextTesting.registerToolsChangedCallback).toBe(
       'function'
     );
+    // Chrome Canary (M139+) ontoolchange property
+    expect('ontoolchange' in (window as any).navigator.modelContextTesting).toBe(true);
   });
 
   it('should expose window.agent as backward-compat combined API', () => {
@@ -328,6 +330,62 @@ describe('WebMCP Polyfill - modelContextTesting (agent-side API)', () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(callback).toHaveBeenCalled();
+  });
+
+  it('ontoolchange should be called when tools change', async () => {
+    const callback = vi.fn();
+    modelContextTesting.ontoolchange = callback;
+
+    modelContext.registerTool({
+      name: 'test_tool',
+      description: 'Test tool',
+      inputSchema: { type: 'object', properties: {} },
+      execute: vi.fn(),
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(callback).toHaveBeenCalled();
+  });
+
+  it('ontoolchange should replace previous handler', async () => {
+    const callback1 = vi.fn();
+    const callback2 = vi.fn();
+    modelContextTesting.ontoolchange = callback1;
+    modelContextTesting.ontoolchange = callback2;
+
+    modelContext.registerTool({
+      name: 'test_tool',
+      description: 'Test tool',
+      inputSchema: { type: 'object', properties: {} },
+      execute: vi.fn(),
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(callback1).not.toHaveBeenCalled();
+    expect(callback2).toHaveBeenCalled();
+  });
+
+  it('ontoolchange getter should return the current handler', () => {
+    expect(modelContextTesting.ontoolchange).toBeNull();
+    const callback = vi.fn();
+    modelContextTesting.ontoolchange = callback;
+    expect(modelContextTesting.ontoolchange).toBe(callback);
+  });
+
+  it('setting ontoolchange to null should remove the handler', async () => {
+    const callback = vi.fn();
+    modelContextTesting.ontoolchange = callback;
+    modelContextTesting.ontoolchange = null;
+
+    modelContext.registerTool({
+      name: 'test_tool',
+      description: 'Test tool',
+      inputSchema: { type: 'object', properties: {} },
+      execute: vi.fn(),
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(callback).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
Chrome 147 introduced [ontoolchange](https://chromium-review.googlesource.com/c/chromium/src/+/7603773), and then [removed registerToolsChangedCallback](https://chromium-review.googlesource.com/c/chromium/src/+/7603273).

This PR adjusts the extension to deal with that.

I haven't tested this locally just yet, as I can't sideload extensions on my work machine..