### PR TITLE
Use document.modelContext to bail out of the polyfill

### DIFF
--- a/src/content-scripts/webmcp-polyfill.js
+++ b/src/content-scripts/webmcp-polyfill.js
@@ -21,7 +21,7 @@
     // Still set up window.agent alias for backward compat if not present
     if (!('agent' in window)) {
       Object.defineProperty(window, 'agent', {
-        value: navigator.modelContext || document.modelContext,
+        value: document.modelContext || navigator.modelContext,
         writable: false,
         configurable: false,
         enumerable: true

--- a/src/content-scripts/webmcp-polyfill.js
+++ b/src/content-scripts/webmcp-polyfill.js
@@ -16,12 +16,12 @@
   'use strict';
 
   // Guard: already initialized (either by us or native browser support)
-  if ('modelContext' in navigator) {
+  if ('modelContext' in navigator || 'modelContext' in document) {
     console.log('[WebMCP] Native navigator.modelContext detected, skipping polyfill');
     // Still set up window.agent alias for backward compat if not present
     if (!('agent' in window)) {
       Object.defineProperty(window, 'agent', {
-        value: navigator.modelContext,
+        value: navigator.modelContext || document.modelContext,
         writable: false,
         configurable: false,
         enumerable: true


### PR DESCRIPTION
Chrome M150 changed `navigator.modelContext` to `document.modelContext`. This PR ensures the polyfill is aware of that, and backs off when document.modelContext is defined.