### PR TITLE
Delay polyfill registration to enable 3P OT

### DIFF
--- a/src/content-scripts/page-bridge.js
+++ b/src/content-scripts/page-bridge.js
@@ -214,13 +214,25 @@
     console.log('[WebMCP Bridge] Ready and listening');
   }
 
-  // Initialize immediately if any WebMCP API exists
-  const agentAPI = getAgentAPI();
-  if (agentAPI) {
+  // Guard against initializing more than once (injection + ready event could both fire)
+  let bridgeInitialized = false;
+  function initBridgeOnce() {
+    if (bridgeInitialized || !getAgentAPI()) return;
+    bridgeInitialized = true;
     initBridge();
+  }
+
+  // The polyfill defers its API registration to DOMContentLoaded (so OriginTrial
+  // registrants can enable the native API first), so the WebMCP API may not exist
+  // when we're injected. Instead of giving up, wait for the 'webmcp:polyfill-ready'
+  // signal. Native APIs are present immediately, so this also handles them without delay.
+  if (getAgentAPI()) {
+    initBridgeOnce();
+  } else if (!window.__webmcpReady) {
+    console.log('[WebMCP Bridge] WebMCP API not ready yet, waiting for polyfill');
+    window.addEventListener('webmcp:polyfill-ready', initBridgeOnce, { once: true });
   } else {
-    // If no API exists yet, it might be loaded later
-    // This shouldn't happen if polyfill is injected at document_start
-    console.warn('[WebMCP Bridge] No WebMCP API found at injection time');
+    // Ready flag set but no API surfaced — nothing to bridge (should not happen)
+    console.warn('[WebMCP Bridge] Polyfill ready but no WebMCP API found');
   }
 })();

--- a/src/content-scripts/webmcp-polyfill.js
+++ b/src/content-scripts/webmcp-polyfill.js
@@ -12,10 +12,43 @@
  * - navigator.modelContextTesting (agent-side: listTools, executeTool, registerToolsChangedCallback)
  * - navigator.modelContext (page-side: provideContext, registerTool) - when available
  */
-(function () {
+(function installWebmcpPolyfill(domContentLoadedEvent) {
   'use strict';
 
-  // Guard: already initialized (either by us or native browser support)
+  // Defer registration until DOMContentLoaded. This content script runs at
+  // document_start (readyState === 'loading'), before the parser has processed any
+  // OriginTrial meta tokens or run page scripts. OriginTrial tokens are applied
+  // during parsing, so by DOMContentLoaded the native modelContext API is enabled
+  // if the trial is present, letting us correctly defer to native instead of
+  // installing our polyfill. Re-running at the page's own DCL also lands before the
+  // extension injects its consumer scripts (page-bridge, tools, user scripts), which
+  // arrive via webNavigation.onDOMContentLoaded — a background round-trip that runs
+  // after the page's DCL handlers — so the API is ready when they need it.
+  //
+  // domContentLoadedEvent is set only when invoked by the listener below; on the
+  // initial synchronous call it is undefined, which is how we tell "defer" from
+  // "install now" without relying on readyState (which some environments don't
+  // advance when the event is dispatched synchronously).
+  if (!domContentLoadedEvent && document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', installWebmcpPolyfill, { once: true });
+    return;
+  }
+
+  // Readiness signal for any consumer that still runs before this does
+  // (defense-in-depth): a window.__webmcpReady flag plus a 'webmcp:polyfill-ready'
+  // event, both emitted once the API (native or polyfill) is ready.
+  function signalReady() {
+    window.__webmcpReady = true;
+    try {
+      window.dispatchEvent(new Event('webmcp:polyfill-ready'));
+    } catch {
+      /* dispatch must never break registration */
+    }
+  }
+
+  // Guard: already initialized (either by us or native browser support).
+  // Re-checked here at DCL time so OriginTrial registrants have had a chance to
+  // enable the native API before we decide to polyfill.
   if ('modelContext' in navigator || 'modelContext' in document) {
     console.log('[WebMCP] Native navigator.modelContext detected, skipping polyfill');
     // Still set up window.agent alias for backward compat if not present
@@ -27,6 +60,7 @@
         enumerable: true
       });
     }
+    signalReady();
     return;
   }
 
@@ -505,4 +539,5 @@
   }
 
   console.log('[WebMCP] Polyfill ready: navigator.modelContext, navigator.modelContextTesting (also: window.agent)');
+  signalReady();
 })();

--- a/src/lib/webmcp/lifecycle.ts
+++ b/src/lib/webmcp/lifecycle.ts
@@ -400,8 +400,11 @@ export class TabManager {
 
       log.debug(`[WebMCP Lifecycle] Injecting scripts into tab ${tabId} (${tab.url})`);
 
-      // Polyfill is injected via manifest content_scripts (world: MAIN, run_at: document_start)
-      // so it's guaranteed to be available before any page scripts run.
+      // Polyfill is injected via manifest content_scripts (world: MAIN, run_at: document_start),
+      // but it DEFERS its API registration to DOMContentLoaded so OriginTrial registrants can
+      // enable the native modelContext first. It is therefore NOT guaranteed to be present when
+      // the scripts below are injected. Each consumer (page-bridge, built-in tools, user scripts)
+      // tolerates a late polyfill by waiting for the 'webmcp:polyfill-ready' signal / window.agent.
 
       // 1. Inject the relay content script (isolated world)
       // CRITICAL: Must be first so it's listening when bridge sends initial snapshot

--- a/src/lib/webmcp/script-injector.ts
+++ b/src/lib/webmcp/script-injector.ts
@@ -70,34 +70,49 @@ function wrapScriptForInjection(code: string, metadata: UserScriptMetadata): str
       hasShouldRegister: typeof shouldRegister !== 'undefined'
     });
 
-    if (typeof shouldRegister === 'function') {
-      try {
-        if (!shouldRegister()) {
-          console.log('[WebMCP] Tool ${scriptName} skipped registration (shouldRegister returned false)');
-          return;
+    // Registration must wait for window.agent, which is installed by the polyfill.
+    // The polyfill registers asynchronously (deferred to DOMContentLoaded so OriginTrial
+    // registrants can enable the native API first), so window.agent may not exist yet.
+    function registerNow() {
+      if (typeof shouldRegister === 'function') {
+        try {
+          if (!shouldRegister()) {
+            console.log('[WebMCP] Tool ${scriptName} skipped registration (shouldRegister returned false)');
+            return;
+          }
+        } catch (error) {
+          console.error('[WebMCP] Error in shouldRegister for ${scriptName}:', error);
+          // Continue with registration if shouldRegister throws (fail-open)
         }
-      } catch (error) {
-        console.error('[WebMCP] Error in shouldRegister for ${scriptName}:', error);
-        // Continue with registration if shouldRegister throws (fail-open)
+      }
+
+      if (window.agent && typeof metadata !== 'undefined' && typeof execute !== 'undefined') {
+        const tool = {
+          name: '${toolName}',
+          description: metadata.description || '${metadata.description || ''}',
+          inputSchema: metadata.inputSchema || { type: 'object', properties: {} },
+          execute: execute
+        };
+
+        window.agent.registerTool(tool);
+        console.log('[WebMCP] Registered tool ${toolName} v${metadata.version}');
+      } else {
+        console.error('[WebMCP] Failed to register ${scriptName}:', {
+          hasAgent: !!window.agent,
+          hasMetadata: typeof metadata !== 'undefined',
+          hasExecute: typeof execute !== 'undefined'
+        });
       }
     }
 
-    if (window.agent && typeof metadata !== 'undefined' && typeof execute !== 'undefined') {
-      const tool = {
-        name: '${toolName}',
-        description: metadata.description || '${metadata.description || ''}',
-        inputSchema: metadata.inputSchema || { type: 'object', properties: {} },
-        execute: execute
-      };
-
-      window.agent.registerTool(tool);
-      console.log('[WebMCP] Registered tool ${toolName} v${metadata.version}');
+    if (window.agent) {
+      registerNow();
+    } else if (window.__webmcpReady) {
+      // Polyfill finished but did not install window.agent — register anyway to log diagnostics.
+      registerNow();
     } else {
-      console.error('[WebMCP] Failed to register ${scriptName}:', {
-        hasAgent: !!window.agent,
-        hasMetadata: typeof metadata !== 'undefined',
-        hasExecute: typeof execute !== 'undefined'
-      });
+      console.log('[WebMCP] window.agent not ready for ${scriptName}, waiting for polyfill');
+      window.addEventListener('webmcp:polyfill-ready', registerNow, { once: true });
     }
 
   } catch (error) {

--- a/tests/webmcp-polyfill.test.ts
+++ b/tests/webmcp-polyfill.test.ts
@@ -33,6 +33,8 @@ describe('WebMCP Polyfill - API Location', () => {
     const script = dom.window.document.createElement('script');
     script.textContent = polyfillCode;
     dom.window.document.body.appendChild(script);
+    // Polyfill defers registration to DOMContentLoaded (installed at document_start in prod)
+    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
   });
 
   it('should expose navigator.modelContext (page-side API per WebMCP spec)', () => {
@@ -90,6 +92,8 @@ describe('WebMCP Polyfill - unregisterTool', () => {
     const script = dom.window.document.createElement('script');
     script.textContent = polyfillCode;
     dom.window.document.body.appendChild(script);
+    // Polyfill defers registration to DOMContentLoaded (installed at document_start in prod)
+    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
 
     modelContext = (window as any).navigator.modelContext;
     modelContextTesting = (window as any).navigator.modelContextTesting;
@@ -139,6 +143,8 @@ describe('WebMCP Polyfill - clearContext', () => {
     const script = dom.window.document.createElement('script');
     script.textContent = polyfillCode;
     dom.window.document.body.appendChild(script);
+    // Polyfill defers registration to DOMContentLoaded (installed at document_start in prod)
+    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
 
     modelContext = (window as any).navigator.modelContext;
     modelContextTesting = (window as any).navigator.modelContextTesting;
@@ -212,6 +218,8 @@ describe('WebMCP Polyfill - modelContextTesting (agent-side API)', () => {
     const script = dom.window.document.createElement('script');
     script.textContent = polyfillCode;
     dom.window.document.body.appendChild(script);
+    // Polyfill defers registration to DOMContentLoaded (installed at document_start in prod)
+    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
 
     modelContext = (window as any).navigator.modelContext;
     modelContextTesting = (window as any).navigator.modelContextTesting;
@@ -442,6 +450,8 @@ describe('WebMCP Polyfill - agent context in execute', () => {
     const script = dom.window.document.createElement('script');
     script.textContent = polyfillCode;
     dom.window.document.body.appendChild(script);
+    // Polyfill defers registration to DOMContentLoaded (installed at document_start in prod)
+    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
 
     modelContext = (window as any).navigator.modelContext;
     modelContextTesting = (window as any).navigator.modelContextTesting;
@@ -512,6 +522,8 @@ describe('WebMCP Polyfill - provideContext tolerance', () => {
     const script = dom.window.document.createElement('script');
     script.textContent = polyfillCode;
     dom.window.document.body.appendChild(script);
+    // Polyfill defers registration to DOMContentLoaded (installed at document_start in prod)
+    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
 
     modelContext = (window as any).navigator.modelContext;
     modelContextTesting = (window as any).navigator.modelContextTesting;
@@ -598,6 +610,8 @@ describe('WebMCP Polyfill - annotations', () => {
     const script = dom.window.document.createElement('script');
     script.textContent = polyfillCode;
     dom.window.document.body.appendChild(script);
+    // Polyfill defers registration to DOMContentLoaded (installed at document_start in prod)
+    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
 
     modelContext = (window as any).navigator.modelContext;
     modelContextTesting = (window as any).navigator.modelContextTesting;
@@ -680,6 +694,8 @@ describe('WebMCP Polyfill - JSON Schema Validation', () => {
     const script = dom.window.document.createElement('script');
     script.textContent = polyfillCode;
     dom.window.document.body.appendChild(script);
+    // Polyfill defers registration to DOMContentLoaded (installed at document_start in prod)
+    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
 
     // Use window.agent (backward compat API with both page-side and agent-side methods)
     agent = (window as any).agent;


### PR DESCRIPTION
The current polyfill registration misses 3P-OT-based registration, that happens async.

As such, the polyfill registers itself before the OT enabled `document.modelContext`.

This PR changes that by moving the polyfill registration to happen at DCL, and by changing parts of the code that relied on an early registration.