### PR TITLE
Change polyfill shape to match latest

### DIFF
--- a/src/content-scripts/page-bridge.js
+++ b/src/content-scripts/page-bridge.js
@@ -1,10 +1,11 @@
 /**
  * WebMCP Page Bridge (MAIN World)
- * Bridges navigator.modelContext events to the extension via postMessage
+ * Bridges document.modelContext events to the extension via postMessage
  * Executes in MAIN world with full access to page runtime
  *
- * Aligns with WebMCP proposed spec:
- * https://github.com/webmachinelearning/webmcp/blob/main/docs/proposal.md
+ * Aligns with the current WebMCP shape (Chrome 150+): the page-side and agent-side
+ * APIs are unified on document.modelContext (navigator.modelContext is the deprecated
+ * alias). There is no more navigator.modelContextTesting.
  */
 (function () {
   'use strict';
@@ -27,43 +28,62 @@
   }
 
   /**
-   * Get the agent-side API for discovering and executing tools
-   * 
-   * Chrome's WebMCP implementation:
-   * - navigator.modelContextTesting = agent-side (listTools, executeTool, registerToolsChangedCallback)
-   * - navigator.modelContext = page-side (registerTool, unregisterTool, provideContext)
-   * 
-   * Our polyfill provides the same separation.
+   * Strip native-only / non-serializable fields (e.g. the tool's `window`) so the
+   * descriptors survive structured-clone when posted to the extension. inputSchema
+   * is left as-is (a JSON string in the native shape); the background parses it.
+   */
+  function sanitizeTools(list) {
+    return (list || []).map((t) => {
+      const entry = { name: t.name, description: t.description, inputSchema: t.inputSchema };
+      if (t.annotations != null) entry.annotations = t.annotations;
+      return entry;
+    });
+  }
+
+  /**
+   * Get the WebMCP agent-side API for discovering and executing tools.
+   *
+   * Current shape (Chrome 150+): everything lives on document.modelContext
+   * (navigator.modelContext is the deprecated alias; our polyfill mirrors both).
+   *   - getTools({ fromOrigins })                async discovery
+   *   - executeTool(toolObject, argsJson)        async execution (takes the tool obj)
+   *   - 'toolchange' event                       via addEventListener
    */
   function getAgentAPI() {
-    // Use modelContextTesting (agent-side API) - either native Chrome or our polyfill
-    if ('modelContextTesting' in navigator) {
-      const mct = navigator.modelContextTesting;
-      const isNative = !Object.prototype.hasOwnProperty.call(mct, 'errors'); // Native won't have our errors property
+    const mc = (typeof document !== 'undefined' && document.modelContext) || navigator.modelContext;
+
+    if (mc && typeof mc.getTools === 'function') {
+      // Our polyfill tags modelContext with an `errors` property; native does not.
+      const native = !Object.prototype.hasOwnProperty.call(mc, 'errors');
       return {
-        native: isNative,
-        listTools: () => mct.listTools(),
-        // executeTool expects args as JSON string
-        executeTool: (name, args) => mct.executeTool(name, JSON.stringify(args)),
-        registerToolsChangedCallback: (callback) => {
-          // TODO: Remove registerToolsChangedCallback fallback once Chrome stable ships ontoolchange (M147+)
-          if ('ontoolchange' in mct) {
-            mct.ontoolchange = callback;
-          } else if (typeof mct.registerToolsChangedCallback === 'function') {
-            mct.registerToolsChangedCallback(callback);
-          } else {
-            console.warn('[WebMCP Bridge] No tools-changed callback mechanism found on modelContextTesting');
-          }
-        }
+        native,
+        // Async snapshot of serializable descriptors.
+        listTools: async () => sanitizeTools(await mc.getTools()),
+        // Native executeTool takes the tool OBJECT + JSON-string args; resolve name -> tool.
+        executeTool: async (name, args) => {
+          const list = await mc.getTools();
+          const tool = list.find((t) => t && t.name === name);
+          if (!tool) throw new Error(`Tool '${name}' not found`);
+          return mc.executeTool(tool, JSON.stringify(args ?? {}));
+        },
+        // Fires whenever the tool list changes.
+        subscribe: (cb) => mc.addEventListener('toolchange', cb)
       };
     }
-    // Legacy fallback: window.agent (backward compat API)
-    if ('agent' in window) {
+
+    // Legacy fallback: window.agent shim (older AgentBoard polyfills).
+    if (window.agent && typeof window.agent.getTools === 'function') {
+      const a = window.agent;
       return {
         native: false,
-        listTools: () => window.agent.listTools(),
-        executeTool: (name, args) => window.agent.callTool(name, args),
-        registerToolsChangedCallback: (callback) => window.agent.addEventListener('tools/listChanged', callback)
+        listTools: async () => sanitizeTools(await a.getTools()),
+        executeTool: async (name, args) => {
+          const list = await a.getTools();
+          const tool = list.find((t) => t && t.name === name);
+          if (!tool) throw new Error(`Tool '${name}' not found`);
+          return a.executeTool(tool, JSON.stringify(args ?? {}));
+        },
+        subscribe: (cb) => a.addEventListener('toolchange', cb)
       };
     }
     return null;
@@ -72,52 +92,51 @@
   /**
    * Initialize bridge using the agent-side API
    */
-  function initBridge() {
+  async function initBridge() {
     const agentAPI = getAgentAPI();
 
     if (!agentAPI) {
-      console.warn('[WebMCP Bridge] No WebMCP API found (modelContextTesting, modelContext, or agent)');
+      console.warn('[WebMCP Bridge] No WebMCP API found (document.modelContext, navigator.modelContext, or window.agent)');
       return;
     }
 
     console.log('[WebMCP Bridge] Initializing in MAIN world', agentAPI.native ? '(native Chrome API)' : '(polyfill)');
 
-    // Get current tools immediately - in case any were registered before we got here
-    const currentTools = agentAPI.listTools();
-    console.log('[WebMCP Bridge] Current tools on init:', currentTools);
-
-    // Send initial snapshot if there are already tools
-    if (currentTools.length > 0) {
+    // Fetch the current tool list and forward it to the extension as tools/listChanged.
+    const forwardTools = async (extra) => {
+      const tools = await agentAPI.listTools();
       postToExtension({
         jsonrpc: JSONRPC,
         method: 'tools/listChanged',
         params: {
-          tools: currentTools,
+          tools,
           origin: location.origin,
           timestamp: Date.now(),
-          initial: true
+          ...(extra || {})
         }
       });
-      console.log('[WebMCP Bridge] Sent initial snapshot with', currentTools.length, 'existing tools');
+      return tools;
+    };
+
+    // Send initial snapshot if there are already tools (registered before we got here)
+    try {
+      const currentTools = await agentAPI.listTools();
+      console.log('[WebMCP Bridge] Current tools on init:', currentTools);
+      if (currentTools.length > 0) {
+        await forwardTools({ initial: true });
+        console.log('[WebMCP Bridge] Sent initial snapshot with', currentTools.length, 'existing tools');
+      }
+    } catch (err) {
+      console.error('[WebMCP Bridge] Failed initial tools snapshot:', err);
     }
 
-    // Subscribe to tool registry changes
-    agentAPI.registerToolsChangedCallback(() => {
-      try {
-        const tools = agentAPI.listTools();
-        postToExtension({
-          jsonrpc: JSONRPC,
-          method: 'tools/listChanged',
-          params: {
-            tools,
-            origin: location.origin,
-            timestamp: Date.now()
-          }
-        });
-        console.log('[WebMCP Bridge] Forwarded tools/listChanged', tools.length, 'tools');
-      } catch (err) {
-        console.error('[WebMCP Bridge] Failed to forward tools/listChanged:', err);
-      }
+    // Subscribe to tool registry changes ('toolchange' event)
+    agentAPI.subscribe(() => {
+      forwardTools()
+        .then((tools) =>
+          console.log('[WebMCP Bridge] Forwarded tools/listChanged', tools.length, 'tools')
+        )
+        .catch((err) => console.error('[WebMCP Bridge] Failed to forward tools/listChanged:', err));
     });
 
     // Listen for requests from extension
@@ -139,20 +158,7 @@
         console.log('[WebMCP Bridge] Received tools/list request');
 
         try {
-          const tools = agentAPI.listTools();
-
-          // Send tools via notification (not a response to preserve protocol semantics)
-          postToExtension({
-            jsonrpc: JSONRPC,
-            method: 'tools/listChanged',
-            params: {
-              tools,
-              origin: location.origin,
-              timestamp: Date.now(),
-              requested: true // Flag to indicate this was explicitly requested
-            }
-          });
-
+          const tools = await forwardTools({ requested: true });
           console.log('[WebMCP Bridge] Sent tools list:', tools.length, 'tools');
         } catch (error) {
           console.error('[WebMCP Bridge] Failed to list tools:', error);

--- a/src/content-scripts/page-bridge.js
+++ b/src/content-scripts/page-bridge.js
@@ -214,13 +214,25 @@
     console.log('[WebMCP Bridge] Ready and listening');
   }
 
-  // Initialize immediately if any WebMCP API exists
-  const agentAPI = getAgentAPI();
-  if (agentAPI) {
+  // Guard against initializing more than once (injection + ready event could both fire)
+  let bridgeInitialized = false;
+  function initBridgeOnce() {
+    if (bridgeInitialized || !getAgentAPI()) return;
+    bridgeInitialized = true;
     initBridge();
+  }
+
+  // The polyfill defers its API registration to DOMContentLoaded (so OriginTrial
+  // registrants can enable the native API first), so the WebMCP API may not exist
+  // when we're injected. Instead of giving up, wait for the 'webmcp:polyfill-ready'
+  // signal. Native APIs are present immediately, so this also handles them without delay.
+  if (getAgentAPI()) {
+    initBridgeOnce();
+  } else if (!window.__webmcpReady) {
+    console.log('[WebMCP Bridge] WebMCP API not ready yet, waiting for polyfill');
+    window.addEventListener('webmcp:polyfill-ready', initBridgeOnce, { once: true });
   } else {
-    // If no API exists yet, it might be loaded later
-    // This shouldn't happen if polyfill is injected at document_start
-    console.warn('[WebMCP Bridge] No WebMCP API found at injection time');
+    // Ready flag set but no API surfaced — nothing to bridge (should not happen)
+    console.warn('[WebMCP Bridge] Polyfill ready but no WebMCP API found');
   }
 })();

--- a/src/content-scripts/webmcp-polyfill.js
+++ b/src/content-scripts/webmcp-polyfill.js
@@ -12,10 +12,43 @@
  * - navigator.modelContextTesting (agent-side: listTools, executeTool, registerToolsChangedCallback)
  * - navigator.modelContext (page-side: provideContext, registerTool) - when available
  */
-(function () {
+(function installWebmcpPolyfill(domContentLoadedEvent) {
   'use strict';
 
-  // Guard: already initialized (either by us or native browser support)
+  // Defer registration until DOMContentLoaded. This content script runs at
+  // document_start (readyState === 'loading'), before the parser has processed any
+  // OriginTrial meta tokens or run page scripts. OriginTrial tokens are applied
+  // during parsing, so by DOMContentLoaded the native modelContext API is enabled
+  // if the trial is present, letting us correctly defer to native instead of
+  // installing our polyfill. Re-running at the page's own DCL also lands before the
+  // extension injects its consumer scripts (page-bridge, tools, user scripts), which
+  // arrive via webNavigation.onDOMContentLoaded — a background round-trip that runs
+  // after the page's DCL handlers — so the API is ready when they need it.
+  //
+  // domContentLoadedEvent is set only when invoked by the listener below; on the
+  // initial synchronous call it is undefined, which is how we tell "defer" from
+  // "install now" without relying on readyState (which some environments don't
+  // advance when the event is dispatched synchronously).
+  if (!domContentLoadedEvent && document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', installWebmcpPolyfill, { once: true });
+    return;
+  }
+
+  // Readiness signal for any consumer that still runs before this does
+  // (defense-in-depth): a window.__webmcpReady flag plus a 'webmcp:polyfill-ready'
+  // event, both emitted once the API (native or polyfill) is ready.
+  function signalReady() {
+    window.__webmcpReady = true;
+    try {
+      window.dispatchEvent(new Event('webmcp:polyfill-ready'));
+    } catch {
+      /* dispatch must never break registration */
+    }
+  }
+
+  // Guard: already initialized (either by us or native browser support).
+  // Re-checked here at DCL time so OriginTrial registrants have had a chance to
+  // enable the native API before we decide to polyfill.
   if ('modelContext' in navigator || 'modelContext' in document) {
     console.log('[WebMCP] Native navigator.modelContext detected, skipping polyfill');
     // Still set up window.agent alias for backward compat if not present
@@ -27,6 +60,7 @@
         enumerable: true
       });
     }
+    signalReady();
     return;
   }
 
@@ -505,4 +539,5 @@
   }
 
   console.log('[WebMCP] Polyfill ready: navigator.modelContext, navigator.modelContextTesting (also: window.agent)');
+  signalReady();
 })();

--- a/src/content-scripts/webmcp-polyfill.js
+++ b/src/content-scripts/webmcp-polyfill.js
@@ -5,12 +5,15 @@
  * Aligns with WebMCP proposed spec:
  * https://github.com/webmachinelearning/webmcp/blob/main/docs/proposal.md
  *
- * API: window.navigator.modelContext
- * Backward compat: window.agent (alias)
+ * Primary API: document.modelContext (Chrome 150+; navigator.modelContext is the
+ * deprecated alias and is mirrored for older callers).
+ * Backward compat: window.agent (thin alias for AgentBoard's own injected tools).
  *
- * Chrome Canary native support:
- * - navigator.modelContextTesting (agent-side: listTools, executeTool, registerToolsChangedCallback)
- * - navigator.modelContext (page-side: provideContext, registerTool) - when available
+ * Matches the native document.modelContext shape:
+ * - registerTool(tool, { signal })          page-side; AbortSignal unregisters
+ * - getTools({ fromOrigins })               agent-side discovery (async)
+ * - executeTool(tool, argsJson, { signal })  agent-side execution (async)
+ * - 'toolchange' event                       fired via addEventListener
  */
 (function installWebmcpPolyfill(domContentLoadedEvent) {
   'use strict';
@@ -219,29 +222,6 @@
     return errors;
   }
 
-  // Lightweight EventTarget-like impl
-  function createEventTarget() {
-    const listeners = new Map();
-    return {
-      addEventListener(type, listener) {
-        if (typeof listener !== 'function') return;
-        if (!listeners.has(type)) listeners.set(type, new Set());
-        listeners.get(type).add(listener);
-      },
-      removeEventListener(type, listener) {
-        if (!listeners.has(type)) return;
-        listeners.get(type).delete(listener);
-      },
-      dispatchEvent(event) {
-        const cbs = listeners.get(event.type);
-        if (!cbs) return;
-        cbs.forEach(cb => {
-          try { cb.call(this, event); } catch { /* swallow to not break others */ }
-        });
-      }
-    };
-  }
-
   /**
    * Create an agent context object to pass to tool execute functions
    * Per WebMCP spec, this provides requestUserInteraction() API
@@ -270,22 +250,10 @@
     };
   }
 
-  // Shared state between page-side (modelContext) and agent-side (modelContextTesting) APIs
+  // Shared tool registry, keyed by name. We keep the parsed (object) inputSchema and
+  // the execute() fn internally; getTools() exposes the native-shaped descriptor with
+  // inputSchema serialized as a JSON string.
   const tools = new Map();
-  const events = createEventTarget();
-  const toolsChangedCallbacks = [];
-  let ontoolchangeHandler = null;
-
-  // Forward internal events to toolsChangedCallbacks
-  events.addEventListener('tools/listChanged', () => {
-    for (const callback of toolsChangedCallbacks) {
-      try {
-        callback();
-      } catch (err) {
-        console.error('[WebMCP] Error in toolsChangedCallback:', err);
-      }
-    }
-  });
 
   function validateAndNormalizeTool(tool) {
     if (!tool || typeof tool !== 'object') {
@@ -307,8 +275,8 @@
   }
 
   /**
-   * Internal function to execute a tool
-   * Used by both modelContext.callTool (legacy) and modelContextTesting.executeTool
+   * Internal function to execute a tool by name with parsed (object) params.
+   * Backs modelContext.executeTool() and the window.agent legacy shim.
    */
   async function executeToolInternal(toolName, params = {}) {
     if (!tools.has(toolName)) {
@@ -333,142 +301,107 @@
   }
 
   /**
-   * Internal function to list tools
-   * Used by both APIs
+   * Build the native-shaped descriptors returned by getTools(): sorted alphabetically
+   * by name, inputSchema serialized as a JSON string, plus the tool's origin. The
+   * execute() fn is intentionally omitted (agents invoke via executeTool()).
    */
   function listToolsInternal() {
-    return Array.from(tools.values()).map(({ name, description, inputSchema, annotations }) => {
-      const entry = { name, description, inputSchema };
-      if (annotations != null) entry.annotations = annotations;
-      return entry;
-    });
+    return Array.from(tools.values())
+      .map(({ name, description, inputSchema, annotations }) => {
+        const entry = {
+          name,
+          description,
+          inputSchema: typeof inputSchema === 'string' ? inputSchema : JSON.stringify(inputSchema),
+          origin: location.origin
+        };
+        if (annotations != null) entry.annotations = annotations;
+        return entry;
+      })
+      .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
   }
 
   /**
-   * PAGE-SIDE API: navigator.modelContext
-   * For pages to register tools with the agent
+   * WebMCP API: document.modelContext (mirrored on navigator.modelContext).
+   * Matches Chrome's native shape exactly:
+   *   - registerTool(tool, { signal })           page-side; AbortSignal unregisters
+   *   - getTools({ fromOrigins })                agent-side discovery (async)
+   *   - executeTool(tool, argsJson, { signal })  agent-side execution (async)
+   *   - 'toolchange' event                       via addEventListener (EventTarget)
    */
-  const modelContext = {
+  class ModelContext extends EventTarget {
     /**
-     * Replace entire tool set (per WebMCP spec)
-     * Clears any pre-existing tools before registering new ones
+     * Register a single tool. Pass { signal } to unregister when the signal aborts.
+     * Returns a promise to match the native (awaitable) API.
      */
-    provideContext(context) {
-      if (!context || typeof context !== 'object') {
-        throw new ValidationError('provideContext requires an object argument');
-      }
-      const toolList = Array.isArray(context.tools) ? context.tools : [];
-      tools.clear();
-      for (const raw of toolList) {
-        const tool = validateAndNormalizeTool(raw);
-        if (tools.has(tool.name)) {
-          throw new ValidationError(`Duplicate tool name: ${tool.name}`);
-        }
-        tools.set(tool.name, tool);
-      }
-      // Notify listeners
-      queueMicrotask(() => events.dispatchEvent({ type: 'tools/listChanged' }));
-    },
-
-    /**
-     * Register a single tool (per WebMCP spec)
-     * Adds to existing tools without clearing
-     */
-    registerTool(rawTool) {
+    registerTool(rawTool, options = {}) {
       const tool = validateAndNormalizeTool(rawTool);
       if (tools.has(tool.name)) {
         // Allow replacement for hot reload
         console.warn(`[WebMCP] Replacing existing tool: ${tool.name}`);
       }
       tools.set(tool.name, tool);
-      queueMicrotask(() => events.dispatchEvent({ type: 'tools/listChanged' }));
-    },
 
-    /**
-     * Unregister a tool by name (per WebMCP spec)
-     */
-    unregisterTool(toolName) {
-      if (typeof toolName !== 'string') {
-        throw new ValidationError('Tool name must be a string');
+      // AbortSignal-based unregistration (native contract).
+      const signal = options && options.signal;
+      if (signal) {
+        if (signal.aborted) {
+          tools.delete(tool.name);
+        } else {
+          signal.addEventListener(
+            'abort',
+            () => {
+              // Only remove if this exact registration is still the active one.
+              if (tools.get(tool.name) === tool) {
+                tools.delete(tool.name);
+                notifyToolChange();
+              }
+            },
+            { once: true }
+          );
+        }
       }
-      const existed = tools.delete(toolName);
-      if (existed) {
-        queueMicrotask(() => events.dispatchEvent({ type: 'tools/listChanged' }));
-      }
-      return existed;
-    },
 
-    /**
-     * Clear all tools (per Chrome's WebMCP implementation)
-     */
-    clearContext() {
-      const hadTools = tools.size > 0;
-      tools.clear();
-      if (hadTools) {
-        queueMicrotask(() => events.dispatchEvent({ type: 'tools/listChanged' }));
-      }
+      notifyToolChange();
+      return Promise.resolve();
     }
-  };
 
-  /**
-   * AGENT-SIDE API: navigator.modelContextTesting
-   * For agents to discover and call tools registered by pages
-   */
-  const modelContextTesting = {
     /**
-     * List all registered tools (agent-side)
-     * Returns tool descriptors without execute functions
+     * Discover registered tools (agent-side). Async; returns native-shaped
+     * descriptors. fromOrigins is accepted for API compatibility but the polyfill
+     * is single-origin, so only same-origin tools ever exist.
      */
-    listTools() {
+    async getTools() {
       return listToolsInternal();
-    },
+    }
 
     /**
-     * Execute a tool by name (agent-side)
-     * Chrome's native API expects args as JSON string
+     * Execute a tool (agent-side). Native passes the tool object returned by
+     * getTools(); we also accept a bare tool name. args may be a JSON string
+     * (native) or an object (convenience).
      */
-    async executeTool(name, args = '{}') {
-      // Parse args if it's a JSON string (Chrome's native format)
+    async executeTool(tool, args = '{}') {
+      const name = typeof tool === 'string' ? tool : tool && tool.name;
       const parsedArgs = typeof args === 'string' ? JSON.parse(args) : args;
       return executeToolInternal(name, parsedArgs);
-    },
-
-    /**
-     * Register a callback for when tools change (agent-side)
-     * Chrome's native API uses this pattern instead of addEventListener
-     */
-    // TODO: Remove registerToolsChangedCallback once Chrome stable ships ontoolchange (M147+)
-    registerToolsChangedCallback(callback) {
-      if (typeof callback !== 'function') {
-        throw new TypeError('Callback must be a function');
-      }
-      toolsChangedCallbacks.push(callback);
-    },
-    set ontoolchange(callback) {
-      if (callback !== null && typeof callback !== 'function') {
-        throw new TypeError('ontoolchange must be a function or null');
-      }
-      if (ontoolchangeHandler) {
-        const idx = toolsChangedCallbacks.indexOf(ontoolchangeHandler);
-        if (idx !== -1) toolsChangedCallbacks.splice(idx, 1);
-      }
-      ontoolchangeHandler = callback;
-      if (callback) {
-        toolsChangedCallbacks.push(callback);
-      }
-    },
-    get ontoolchange() {
-      return ontoolchangeHandler;
     }
-  };
+  }
 
-  // Make modelContextTesting look like Chrome's native implementation
-  Object.defineProperty(modelContextTesting, Symbol.toStringTag, {
-    value: 'ModelContextTesting',
-    configurable: true
+  const modelContext = new ModelContext();
+
+  // Dispatch 'toolchange' on the next microtask so a burst of synchronous
+  // registrations coalesces into a single notification.
+  function notifyToolChange() {
+    queueMicrotask(() => modelContext.dispatchEvent(new Event('toolchange')));
+  }
+
+  // Define document.modelContext (primary, per Chrome 150+) and mirror it on
+  // navigator.modelContext (deprecated in Chrome 150, kept for older callers).
+  Object.defineProperty(document, 'modelContext', {
+    value: modelContext,
+    writable: false,
+    configurable: false,
+    enumerable: true
   });
-
-  // Define navigator.modelContext (page-side API)
   Object.defineProperty(navigator, 'modelContext', {
     value: modelContext,
     writable: false,
@@ -476,29 +409,16 @@
     enumerable: true
   });
 
-  // Define navigator.modelContextTesting (agent-side API)
-  Object.defineProperty(navigator, 'modelContextTesting', {
-    value: modelContextTesting,
-    writable: false,
-    configurable: false,
-    enumerable: true
-  });
-
-  // Backward compatibility: window.agent combines both APIs for legacy scripts
+  // Backward-compatibility alias for AgentBoard's own injected tools and user
+  // scripts, which register via window.agent.registerTool(...). Thin shim over the
+  // unified modelContext; exposes just enough of the agent-side surface for console use.
   const agentCompat = {
-    // Page-side methods
-    provideContext: modelContext.provideContext.bind(modelContext),
-    registerTool: modelContext.registerTool.bind(modelContext),
-    unregisterTool: modelContext.unregisterTool.bind(modelContext),
-    clearContext: modelContext.clearContext.bind(modelContext),
-    // Agent-side methods (legacy support)
-    listTools: modelContextTesting.listTools.bind(modelContextTesting),
-    callTool: (name, args) => executeToolInternal(name, args), // Direct call, not JSON string
-    // Legacy event API
-    addEventListener: events.addEventListener.bind(events),
-    removeEventListener: events.removeEventListener.bind(events)
+    registerTool: (tool, options) => modelContext.registerTool(tool, options),
+    getTools: () => modelContext.getTools(),
+    executeTool: (tool, args) => modelContext.executeTool(tool, args),
+    addEventListener: (type, cb) => modelContext.addEventListener(type, cb),
+    removeEventListener: (type, cb) => modelContext.removeEventListener(type, cb)
   };
-
   Object.defineProperty(window, 'agent', {
     value: agentCompat,
     writable: false,
@@ -506,7 +426,7 @@
     enumerable: true
   });
 
-  // Expose error classes on all APIs for consumers
+  // Expose error classes for consumers
   const errorClasses = {
     WebMCPError,
     ToolNotFoundError,
@@ -514,7 +434,6 @@
     ExecutionError
   };
   modelContext.errors = errorClasses;
-  modelContextTesting.errors = errorClasses;
   window.agent.errors = errorClasses;
 
   // Create Trusted Types policy for user script injection
@@ -538,6 +457,6 @@
     }
   }
 
-  console.log('[WebMCP] Polyfill ready: navigator.modelContext, navigator.modelContextTesting (also: window.agent)');
+  console.log('[WebMCP] Polyfill ready: document.modelContext (also navigator.modelContext, window.agent)');
   signalReady();
 })();

--- a/src/lib/webmcp/lifecycle.ts
+++ b/src/lib/webmcp/lifecycle.ts
@@ -400,8 +400,11 @@ export class TabManager {
 
       log.debug(`[WebMCP Lifecycle] Injecting scripts into tab ${tabId} (${tab.url})`);
 
-      // Polyfill is injected via manifest content_scripts (world: MAIN, run_at: document_start)
-      // so it's guaranteed to be available before any page scripts run.
+      // Polyfill is injected via manifest content_scripts (world: MAIN, run_at: document_start),
+      // but it DEFERS its API registration to DOMContentLoaded so OriginTrial registrants can
+      // enable the native modelContext first. It is therefore NOT guaranteed to be present when
+      // the scripts below are injected. Each consumer (page-bridge, built-in tools, user scripts)
+      // tolerates a late polyfill by waiting for the 'webmcp:polyfill-ready' signal / window.agent.
 
       // 1. Inject the relay content script (isolated world)
       // CRITICAL: Must be first so it's listening when bridge sends initial snapshot

--- a/src/lib/webmcp/script-injector.ts
+++ b/src/lib/webmcp/script-injector.ts
@@ -70,34 +70,49 @@ function wrapScriptForInjection(code: string, metadata: UserScriptMetadata): str
       hasShouldRegister: typeof shouldRegister !== 'undefined'
     });
 
-    if (typeof shouldRegister === 'function') {
-      try {
-        if (!shouldRegister()) {
-          console.log('[WebMCP] Tool ${scriptName} skipped registration (shouldRegister returned false)');
-          return;
+    // Registration must wait for window.agent, which is installed by the polyfill.
+    // The polyfill registers asynchronously (deferred to DOMContentLoaded so OriginTrial
+    // registrants can enable the native API first), so window.agent may not exist yet.
+    function registerNow() {
+      if (typeof shouldRegister === 'function') {
+        try {
+          if (!shouldRegister()) {
+            console.log('[WebMCP] Tool ${scriptName} skipped registration (shouldRegister returned false)');
+            return;
+          }
+        } catch (error) {
+          console.error('[WebMCP] Error in shouldRegister for ${scriptName}:', error);
+          // Continue with registration if shouldRegister throws (fail-open)
         }
-      } catch (error) {
-        console.error('[WebMCP] Error in shouldRegister for ${scriptName}:', error);
-        // Continue with registration if shouldRegister throws (fail-open)
+      }
+
+      if (window.agent && typeof metadata !== 'undefined' && typeof execute !== 'undefined') {
+        const tool = {
+          name: '${toolName}',
+          description: metadata.description || '${metadata.description || ''}',
+          inputSchema: metadata.inputSchema || { type: 'object', properties: {} },
+          execute: execute
+        };
+
+        window.agent.registerTool(tool);
+        console.log('[WebMCP] Registered tool ${toolName} v${metadata.version}');
+      } else {
+        console.error('[WebMCP] Failed to register ${scriptName}:', {
+          hasAgent: !!window.agent,
+          hasMetadata: typeof metadata !== 'undefined',
+          hasExecute: typeof execute !== 'undefined'
+        });
       }
     }
 
-    if (window.agent && typeof metadata !== 'undefined' && typeof execute !== 'undefined') {
-      const tool = {
-        name: '${toolName}',
-        description: metadata.description || '${metadata.description || ''}',
-        inputSchema: metadata.inputSchema || { type: 'object', properties: {} },
-        execute: execute
-      };
-
-      window.agent.registerTool(tool);
-      console.log('[WebMCP] Registered tool ${toolName} v${metadata.version}');
+    if (window.agent) {
+      registerNow();
+    } else if (window.__webmcpReady) {
+      // Polyfill finished but did not install window.agent — register anyway to log diagnostics.
+      registerNow();
     } else {
-      console.error('[WebMCP] Failed to register ${scriptName}:', {
-        hasAgent: !!window.agent,
-        hasMetadata: typeof metadata !== 'undefined',
-        hasExecute: typeof execute !== 'undefined'
-      });
+      console.log('[WebMCP] window.agent not ready for ${scriptName}, waiting for polyfill');
+      window.addEventListener('webmcp:polyfill-ready', registerNow, { once: true });
     }
 
   } catch (error) {

--- a/tests/webmcp-polyfill.test.ts
+++ b/tests/webmcp-polyfill.test.ts
@@ -33,6 +33,8 @@ describe('WebMCP Polyfill - API Location', () => {
     const script = dom.window.document.createElement('script');
     script.textContent = polyfillCode;
     dom.window.document.body.appendChild(script);
+    // Polyfill defers registration to DOMContentLoaded (installed at document_start in prod)
+    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
   });
 
   it('should expose navigator.modelContext (page-side API per WebMCP spec)', () => {
@@ -90,6 +92,8 @@ describe('WebMCP Polyfill - unregisterTool', () => {
     const script = dom.window.document.createElement('script');
     script.textContent = polyfillCode;
     dom.window.document.body.appendChild(script);
+    // Polyfill defers registration to DOMContentLoaded (installed at document_start in prod)
+    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
 
     modelContext = (window as any).navigator.modelContext;
     modelContextTesting = (window as any).navigator.modelContextTesting;
@@ -139,6 +143,8 @@ describe('WebMCP Polyfill - clearContext', () => {
     const script = dom.window.document.createElement('script');
     script.textContent = polyfillCode;
     dom.window.document.body.appendChild(script);
+    // Polyfill defers registration to DOMContentLoaded (installed at document_start in prod)
+    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
 
     modelContext = (window as any).navigator.modelContext;
     modelContextTesting = (window as any).navigator.modelContextTesting;
@@ -212,6 +218,8 @@ describe('WebMCP Polyfill - modelContextTesting (agent-side API)', () => {
     const script = dom.window.document.createElement('script');
     script.textContent = polyfillCode;
     dom.window.document.body.appendChild(script);
+    // Polyfill defers registration to DOMContentLoaded (installed at document_start in prod)
+    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
 
     modelContext = (window as any).navigator.modelContext;
     modelContextTesting = (window as any).navigator.modelContextTesting;
@@ -442,6 +450,8 @@ describe('WebMCP Polyfill - agent context in execute', () => {
     const script = dom.window.document.createElement('script');
     script.textContent = polyfillCode;
     dom.window.document.body.appendChild(script);
+    // Polyfill defers registration to DOMContentLoaded (installed at document_start in prod)
+    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
 
     modelContext = (window as any).navigator.modelContext;
     modelContextTesting = (window as any).navigator.modelContextTesting;
@@ -512,6 +522,8 @@ describe('WebMCP Polyfill - provideContext tolerance', () => {
     const script = dom.window.document.createElement('script');
     script.textContent = polyfillCode;
     dom.window.document.body.appendChild(script);
+    // Polyfill defers registration to DOMContentLoaded (installed at document_start in prod)
+    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
 
     modelContext = (window as any).navigator.modelContext;
     modelContextTesting = (window as any).navigator.modelContextTesting;
@@ -598,6 +610,8 @@ describe('WebMCP Polyfill - annotations', () => {
     const script = dom.window.document.createElement('script');
     script.textContent = polyfillCode;
     dom.window.document.body.appendChild(script);
+    // Polyfill defers registration to DOMContentLoaded (installed at document_start in prod)
+    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
 
     modelContext = (window as any).navigator.modelContext;
     modelContextTesting = (window as any).navigator.modelContextTesting;
@@ -680,6 +694,8 @@ describe('WebMCP Polyfill - JSON Schema Validation', () => {
     const script = dom.window.document.createElement('script');
     script.textContent = polyfillCode;
     dom.window.document.body.appendChild(script);
+    // Polyfill defers registration to DOMContentLoaded (installed at document_start in prod)
+    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
 
     // Use window.agent (backward compat API with both page-side and agent-side methods)
     agent = (window as any).agent;

--- a/tests/webmcp-polyfill.test.ts
+++ b/tests/webmcp-polyfill.test.ts
@@ -1,9 +1,14 @@
 /**
  * Tests for WebMCP Polyfill
  *
- * Per WebMCP spec: https://github.com/webmachinelearning/webmcp/blob/main/docs/proposal.md
- * - Primary API: navigator.modelContext
- * - Backward compat: window.agent (alias)
+ * Matches the current WebMCP shape (Chrome 150+): a single unified API on
+ * document.modelContext (mirrored on navigator.modelContext). There is no more
+ * navigator.modelContextTesting — discovery/execution live on modelContext:
+ *   - registerTool(tool, { signal })           page-side; AbortSignal unregisters
+ *   - getTools()                               agent-side discovery (async)
+ *   - executeTool(tool, argsJson)              agent-side execution (async)
+ *   - 'toolchange' event                       via addEventListener
+ * window.agent remains as a thin legacy alias for AgentBoard's injected tools.
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
@@ -12,94 +17,81 @@ import { JSDOM } from 'jsdom';
 import fs from 'fs';
 import path from 'path';
 
+const polyfillCode = fs.readFileSync(
+  path.join(__dirname, '../src/content-scripts/webmcp-polyfill.js'),
+  'utf8'
+);
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+/**
+ * Load the polyfill into a fresh JSDOM window. The polyfill defers registration to
+ * DOMContentLoaded (it runs at document_start in prod), so we dispatch that event.
+ */
+function loadPolyfill() {
+  const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+    url: 'https://example.com',
+    runScripts: 'dangerously',
+  });
+
+  const window = dom.window as any;
+  global.window = window as any;
+
+  const script = dom.window.document.createElement('script');
+  script.textContent = polyfillCode;
+  dom.window.document.body.appendChild(script);
+  dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+
+  return {
+    dom,
+    window,
+    modelContext: window.document.modelContext,
+    agent: window.agent,
+  };
+}
+
 describe('WebMCP Polyfill - API Location', () => {
-  let dom: JSDOM;
-  let window: Window & typeof globalThis;
+  let window: any;
+  let modelContext: any;
+  let agent: any;
 
   beforeEach(() => {
-    dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
-      url: 'https://example.com',
-      runScripts: 'dangerously',
-    });
-
-    window = dom.window as any;
-    global.window = window as any;
-
-    const polyfillCode = fs.readFileSync(
-      path.join(__dirname, '../src/content-scripts/webmcp-polyfill.js'),
-      'utf8'
-    );
-
-    const script = dom.window.document.createElement('script');
-    script.textContent = polyfillCode;
-    dom.window.document.body.appendChild(script);
-    // Polyfill defers registration to DOMContentLoaded (installed at document_start in prod)
-    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+    ({ window, modelContext, agent } = loadPolyfill());
   });
 
-  it('should expose navigator.modelContext (page-side API per WebMCP spec)', () => {
-    expect((window as any).navigator.modelContext).toBeDefined();
-    // Page-side methods only
-    expect(typeof (window as any).navigator.modelContext.provideContext).toBe('function');
-    expect(typeof (window as any).navigator.modelContext.registerTool).toBe('function');
-    expect(typeof (window as any).navigator.modelContext.unregisterTool).toBe('function');
-    expect(typeof (window as any).navigator.modelContext.clearContext).toBe('function');
-    // Agent-side methods should NOT be on modelContext
-    expect((window as any).navigator.modelContext.callTool).toBeUndefined();
-    expect((window as any).navigator.modelContext.listTools).toBeUndefined();
+  it('should expose document.modelContext with the unified API', () => {
+    expect(window.document.modelContext).toBeDefined();
+    expect(typeof modelContext.registerTool).toBe('function');
+    expect(typeof modelContext.getTools).toBe('function');
+    expect(typeof modelContext.executeTool).toBe('function');
+    // EventTarget surface for 'toolchange'
+    expect(typeof modelContext.addEventListener).toBe('function');
   });
 
-  it('should expose navigator.modelContextTesting (agent-side API)', () => {
-    expect((window as any).navigator.modelContextTesting).toBeDefined();
-    expect(typeof (window as any).navigator.modelContextTesting.listTools).toBe('function');
-    expect(typeof (window as any).navigator.modelContextTesting.executeTool).toBe('function');
-    expect(typeof (window as any).navigator.modelContextTesting.registerToolsChangedCallback).toBe(
-      'function'
-    );
-    // Chrome M147+ ontoolchange property
-    expect('ontoolchange' in (window as any).navigator.modelContextTesting).toBe(true);
+  it('should mirror modelContext on navigator (deprecated alias)', () => {
+    expect(window.navigator.modelContext).toBe(window.document.modelContext);
   });
 
-  it('should expose window.agent as backward-compat combined API', () => {
-    expect((window as any).agent).toBeDefined();
-    // Should have both page-side and agent-side methods for legacy compat
-    expect(typeof (window as any).agent.registerTool).toBe('function');
-    expect(typeof (window as any).agent.listTools).toBe('function');
-    expect(typeof (window as any).agent.callTool).toBe('function');
+  it('should NOT expose navigator.modelContextTesting (removed in current spec)', () => {
+    expect(window.navigator.modelContextTesting).toBeUndefined();
+  });
+
+  it('should expose window.agent as a thin legacy alias', () => {
+    expect(agent).toBeDefined();
+    expect(typeof agent.registerTool).toBe('function');
+    expect(typeof agent.getTools).toBe('function');
+    expect(typeof agent.executeTool).toBe('function');
   });
 });
 
-describe('WebMCP Polyfill - unregisterTool', () => {
-  let dom: JSDOM;
-  let window: Window & typeof globalThis;
+describe('WebMCP Polyfill - registerTool & getTools', () => {
   let modelContext: any;
-  let modelContextTesting: any;
 
   beforeEach(() => {
-    dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
-      url: 'https://example.com',
-      runScripts: 'dangerously',
-    });
-
-    window = dom.window as any;
-    global.window = window as any;
-
-    const polyfillCode = fs.readFileSync(
-      path.join(__dirname, '../src/content-scripts/webmcp-polyfill.js'),
-      'utf8'
-    );
-
-    const script = dom.window.document.createElement('script');
-    script.textContent = polyfillCode;
-    dom.window.document.body.appendChild(script);
-    // Polyfill defers registration to DOMContentLoaded (installed at document_start in prod)
-    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
-
-    modelContext = (window as any).navigator.modelContext;
-    modelContextTesting = (window as any).navigator.modelContextTesting;
+    ({ modelContext } = loadPolyfill());
   });
 
-  it('should unregister a tool by name', () => {
+  it('should register a tool discoverable via getTools()', async () => {
     modelContext.registerTool({
       name: 'test_tool',
       description: 'Test tool',
@@ -107,354 +99,193 @@ describe('WebMCP Polyfill - unregisterTool', () => {
       execute: vi.fn(),
     });
 
-    expect(modelContextTesting.listTools().length).toBe(1);
-
-    const removed = modelContext.unregisterTool('test_tool');
-    expect(removed).toBe(true);
-    expect(modelContextTesting.listTools().length).toBe(0);
-  });
-
-  it('should return false when unregistering non-existent tool', () => {
-    const removed = modelContext.unregisterTool('non_existent');
-    expect(removed).toBe(false);
-  });
-});
-
-describe('WebMCP Polyfill - clearContext', () => {
-  let dom: JSDOM;
-  let window: Window & typeof globalThis;
-  let modelContext: any;
-  let modelContextTesting: any;
-
-  beforeEach(() => {
-    dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
-      url: 'https://example.com',
-      runScripts: 'dangerously',
-    });
-
-    window = dom.window as any;
-    global.window = window as any;
-
-    const polyfillCode = fs.readFileSync(
-      path.join(__dirname, '../src/content-scripts/webmcp-polyfill.js'),
-      'utf8'
-    );
-
-    const script = dom.window.document.createElement('script');
-    script.textContent = polyfillCode;
-    dom.window.document.body.appendChild(script);
-    // Polyfill defers registration to DOMContentLoaded (installed at document_start in prod)
-    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
-
-    modelContext = (window as any).navigator.modelContext;
-    modelContextTesting = (window as any).navigator.modelContextTesting;
-  });
-
-  it('should clear all tools', () => {
-    modelContext.registerTool({
-      name: 'tool1',
-      description: 'Tool 1',
-      inputSchema: { type: 'object', properties: {} },
-      execute: vi.fn(),
-    });
-    modelContext.registerTool({
-      name: 'tool2',
-      description: 'Tool 2',
-      inputSchema: { type: 'object', properties: {} },
-      execute: vi.fn(),
-    });
-
-    expect(modelContextTesting.listTools().length).toBe(2);
-
-    modelContext.clearContext();
-
-    expect(modelContextTesting.listTools().length).toBe(0);
-  });
-
-  it('should trigger toolsChangedCallback', async () => {
-    const callback = vi.fn();
-    modelContextTesting.registerToolsChangedCallback(callback);
-
-    modelContext.registerTool({
-      name: 'test_tool',
-      description: 'Test tool',
-      inputSchema: { type: 'object', properties: {} },
-      execute: vi.fn(),
-    });
-
-    // Wait for microtask
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    callback.mockClear();
-
-    modelContext.clearContext();
-
-    // Wait for microtask
-    await new Promise((resolve) => setTimeout(resolve, 0));
-
-    expect(callback).toHaveBeenCalled();
-  });
-});
-
-describe('WebMCP Polyfill - modelContextTesting (agent-side API)', () => {
-  let dom: JSDOM;
-  let window: Window & typeof globalThis;
-  let modelContext: any;
-  let modelContextTesting: any;
-
-  beforeEach(() => {
-    dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
-      url: 'https://example.com',
-      runScripts: 'dangerously',
-    });
-
-    window = dom.window as any;
-    global.window = window as any;
-
-    const polyfillCode = fs.readFileSync(
-      path.join(__dirname, '../src/content-scripts/webmcp-polyfill.js'),
-      'utf8'
-    );
-
-    const script = dom.window.document.createElement('script');
-    script.textContent = polyfillCode;
-    dom.window.document.body.appendChild(script);
-    // Polyfill defers registration to DOMContentLoaded (installed at document_start in prod)
-    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
-
-    modelContext = (window as any).navigator.modelContext;
-    modelContextTesting = (window as any).navigator.modelContextTesting;
-  });
-
-  it('should expose navigator.modelContextTesting', () => {
-    expect(modelContextTesting).toBeDefined();
-    expect(typeof modelContextTesting.listTools).toBe('function');
-    expect(typeof modelContextTesting.executeTool).toBe('function');
-    expect(typeof modelContextTesting.registerToolsChangedCallback).toBe('function');
-  });
-
-  it('should have ModelContextTesting as Symbol.toStringTag', () => {
-    expect(modelContextTesting[Symbol.toStringTag]).toBe('ModelContextTesting');
-  });
-
-  it('listTools() should return tools registered via modelContext', () => {
-    modelContext.registerTool({
-      name: 'test_tool',
-      description: 'Test tool',
-      inputSchema: { type: 'object', properties: {} },
-      execute: vi.fn(),
-    });
-
-    const tools = modelContextTesting.listTools();
+    const tools = await modelContext.getTools();
     expect(tools.length).toBe(1);
     expect(tools[0].name).toBe('test_tool');
   });
 
-  it('executeTool() should call tools with JSON string args (Chrome native format)', async () => {
-    const executeFn = vi.fn().mockResolvedValue('result');
+  it('getTools() should serialize inputSchema as a JSON string and include origin (native shape)', async () => {
+    const schema = { type: 'object', properties: { input: { type: 'string' } } };
     modelContext.registerTool({
-      name: 'test_tool',
-      description: 'Test tool',
-      inputSchema: { type: 'object', properties: { input: { type: 'string' } } },
-      execute: executeFn,
-    });
-
-    // Chrome's native API passes args as JSON string
-    const result = await modelContextTesting.executeTool('test_tool', '{"input":"hello"}');
-    expect(result).toBe('result');
-    expect(executeFn).toHaveBeenCalledWith({ input: 'hello' }, expect.any(Object));
-  });
-
-  it('executeTool() should also accept object args for convenience', async () => {
-    const executeFn = vi.fn().mockResolvedValue('result');
-    modelContext.registerTool({
-      name: 'test_tool',
-      description: 'Test tool',
-      inputSchema: { type: 'object', properties: { input: { type: 'string' } } },
-      execute: executeFn,
-    });
-
-    // Also support object for backward compat
-    const result = await modelContextTesting.executeTool('test_tool', { input: 'hello' });
-    expect(result).toBe('result');
-    expect(executeFn).toHaveBeenCalledWith({ input: 'hello' }, expect.any(Object));
-  });
-
-  it('registerToolsChangedCallback() should be called when tools change', async () => {
-    const callback = vi.fn();
-    modelContextTesting.registerToolsChangedCallback(callback);
-
-    modelContext.registerTool({
-      name: 'test_tool',
-      description: 'Test tool',
-      inputSchema: { type: 'object', properties: {} },
+      name: 'schema_tool',
+      description: 'Has schema',
+      inputSchema: schema,
       execute: vi.fn(),
     });
 
-    // Wait for microtask
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    const [tool] = await modelContext.getTools();
+    expect(typeof tool.inputSchema).toBe('string');
+    expect(JSON.parse(tool.inputSchema)).toEqual(schema);
+    expect(tool.origin).toBe('https://example.com');
+    // execute is not exposed to agents
+    expect(tool.execute).toBeUndefined();
+  });
+
+  it('getTools() should return tools sorted alphabetically by name', async () => {
+    modelContext.registerTool({ name: 'zebra', description: 'z', execute: vi.fn() });
+    modelContext.registerTool({ name: 'apple', description: 'a', execute: vi.fn() });
+    modelContext.registerTool({ name: 'mango', description: 'm', execute: vi.fn() });
+
+    const names = (await modelContext.getTools()).map((t: any) => t.name);
+    expect(names).toEqual(['apple', 'mango', 'zebra']);
+  });
+
+  it('registering a tool with an existing name should replace it', async () => {
+    modelContext.registerTool({ name: 'dup', description: 'one', execute: vi.fn() });
+    modelContext.registerTool({ name: 'dup', description: 'two', execute: vi.fn() });
+
+    const tools = await modelContext.getTools();
+    expect(tools.length).toBe(1);
+    expect(tools[0].description).toBe('two');
+  });
+
+  it('registerTool should reject invalid tools', () => {
+    expect(() => modelContext.registerTool({ description: 'no name', execute: vi.fn() })).toThrow(
+      /string name/
+    );
+    expect(() => modelContext.registerTool({ name: 'x', execute: vi.fn() })).toThrow(
+      /string description/
+    );
+    expect(() => modelContext.registerTool({ name: 'x', description: 'd' })).toThrow(
+      /execute function/
+    );
+  });
+});
+
+describe('WebMCP Polyfill - AbortSignal unregistration', () => {
+  let window: any;
+  let modelContext: any;
+
+  beforeEach(() => {
+    ({ window, modelContext } = loadPolyfill());
+  });
+
+  it('should unregister a tool when its AbortSignal fires', async () => {
+    const controller = new window.AbortController();
+    modelContext.registerTool(
+      { name: 'abortable', description: 'd', execute: vi.fn() },
+      { signal: controller.signal }
+    );
+    expect((await modelContext.getTools()).length).toBe(1);
+
+    controller.abort();
+    expect((await modelContext.getTools()).length).toBe(0);
+  });
+
+  it('should not register a tool whose signal is already aborted', async () => {
+    const controller = new window.AbortController();
+    controller.abort();
+    modelContext.registerTool(
+      { name: 'dead', description: 'd', execute: vi.fn() },
+      { signal: controller.signal }
+    );
+    expect((await modelContext.getTools()).length).toBe(0);
+  });
+
+  it('should fire toolchange when a signal unregisters a tool', async () => {
+    const controller = new window.AbortController();
+    modelContext.registerTool(
+      { name: 'abortable', description: 'd', execute: vi.fn() },
+      { signal: controller.signal }
+    );
+    await tick();
+
+    const callback = vi.fn();
+    modelContext.addEventListener('toolchange', callback);
+    controller.abort();
+    await tick();
+
+    expect(callback).toHaveBeenCalled();
+  });
+});
+
+describe('WebMCP Polyfill - toolchange event', () => {
+  let modelContext: any;
+
+  beforeEach(() => {
+    ({ modelContext } = loadPolyfill());
+  });
+
+  it('should fire toolchange when a tool is registered', async () => {
+    const callback = vi.fn();
+    modelContext.addEventListener('toolchange', callback);
+
+    modelContext.registerTool({ name: 'test_tool', description: 'd', execute: vi.fn() });
+    await tick();
 
     expect(callback).toHaveBeenCalled();
   });
 
-  it('registerToolsChangedCallback() should be called on unregisterTool', async () => {
-    modelContext.registerTool({
-      name: 'test_tool',
-      description: 'Test tool',
-      inputSchema: { type: 'object', properties: {} },
-      execute: vi.fn(),
-    });
-
-    // Wait for initial registration callback
-    await new Promise((resolve) => setTimeout(resolve, 0));
-
+  it('should stop firing after removeEventListener', async () => {
     const callback = vi.fn();
-    modelContextTesting.registerToolsChangedCallback(callback);
+    modelContext.addEventListener('toolchange', callback);
+    modelContext.removeEventListener('toolchange', callback);
 
-    modelContext.unregisterTool('test_tool');
+    modelContext.registerTool({ name: 'test_tool', description: 'd', execute: vi.fn() });
+    await tick();
 
-    // Wait for microtask
-    await new Promise((resolve) => setTimeout(resolve, 0));
-
-    expect(callback).toHaveBeenCalled();
-  });
-
-  it('registerToolsChangedCallback() should be called on clearContext', async () => {
-    modelContext.registerTool({
-      name: 'test_tool',
-      description: 'Test tool',
-      inputSchema: { type: 'object', properties: {} },
-      execute: vi.fn(),
-    });
-
-    // Wait for initial registration callback
-    await new Promise((resolve) => setTimeout(resolve, 0));
-
-    const callback = vi.fn();
-    modelContextTesting.registerToolsChangedCallback(callback);
-
-    modelContext.clearContext();
-
-    // Wait for microtask
-    await new Promise((resolve) => setTimeout(resolve, 0));
-
-    expect(callback).toHaveBeenCalled();
-  });
-
-  it('ontoolchange should be called when tools change', async () => {
-    const callback = vi.fn();
-    modelContextTesting.ontoolchange = callback;
-
-    modelContext.registerTool({
-      name: 'test_tool',
-      description: 'Test tool',
-      inputSchema: { type: 'object', properties: {} },
-      execute: vi.fn(),
-    });
-
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(callback).toHaveBeenCalled();
-  });
-
-  it('ontoolchange should replace previous handler', async () => {
-    const callback1 = vi.fn();
-    const callback2 = vi.fn();
-    modelContextTesting.ontoolchange = callback1;
-    modelContextTesting.ontoolchange = callback2;
-
-    modelContext.registerTool({
-      name: 'test_tool',
-      description: 'Test tool',
-      inputSchema: { type: 'object', properties: {} },
-      execute: vi.fn(),
-    });
-
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(callback1).not.toHaveBeenCalled();
-    expect(callback2).toHaveBeenCalled();
-  });
-
-  it('ontoolchange getter should return the current handler', () => {
-    expect(modelContextTesting.ontoolchange).toBeNull();
-    const callback = vi.fn();
-    modelContextTesting.ontoolchange = callback;
-    expect(modelContextTesting.ontoolchange).toBe(callback);
-  });
-
-  it('setting ontoolchange to null should remove the handler', async () => {
-    const callback = vi.fn();
-    modelContextTesting.ontoolchange = callback;
-    modelContextTesting.ontoolchange = null;
-
-    modelContext.registerTool({
-      name: 'test_tool',
-      description: 'Test tool',
-      inputSchema: { type: 'object', properties: {} },
-      execute: vi.fn(),
-    });
-
-    await new Promise((resolve) => setTimeout(resolve, 0));
     expect(callback).not.toHaveBeenCalled();
   });
 
-  it('ontoolchange and registerToolsChangedCallback should both fire', async () => {
-    const callbackViaRegister = vi.fn();
-    const callbackViaOnchange = vi.fn();
-    modelContextTesting.registerToolsChangedCallback(callbackViaRegister);
-    modelContextTesting.ontoolchange = callbackViaOnchange;
+  it('should coalesce a burst of synchronous registrations into notifications', async () => {
+    const callback = vi.fn();
+    modelContext.addEventListener('toolchange', callback);
 
-    modelContext.registerTool({
-      name: 'test_tool',
-      description: 'Test tool',
-      inputSchema: { type: 'object', properties: {} },
-      execute: vi.fn(),
-    });
+    modelContext.registerTool({ name: 'a', description: 'd', execute: vi.fn() });
+    modelContext.registerTool({ name: 'b', description: 'd', execute: vi.fn() });
+    await tick();
 
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(callbackViaRegister).toHaveBeenCalled();
-    expect(callbackViaOnchange).toHaveBeenCalled();
+    expect(callback).toHaveBeenCalled();
+    expect((await modelContext.getTools()).length).toBe(2);
+  });
+});
+
+describe('WebMCP Polyfill - executeTool', () => {
+  let modelContext: any;
+
+  beforeEach(() => {
+    ({ modelContext } = loadPolyfill());
   });
 
-  it('ontoolchange should throw for non-function values', () => {
-    expect(() => {
-      modelContextTesting.ontoolchange = 'not a function';
-    }).toThrow('ontoolchange must be a function or null');
-    expect(() => {
-      modelContextTesting.ontoolchange = 42;
-    }).toThrow('ontoolchange must be a function or null');
-    expect(() => {
-      modelContextTesting.ontoolchange = {};
-    }).toThrow('ontoolchange must be a function or null');
+  it('should execute a tool by tool object with JSON-string args (native shape)', async () => {
+    const executeFn = vi.fn().mockResolvedValue('result');
+    modelContext.registerTool({
+      name: 'test_tool',
+      description: 'd',
+      inputSchema: { type: 'object', properties: { input: { type: 'string' } } },
+      execute: executeFn,
+    });
+
+    const [tool] = await modelContext.getTools();
+    const result = await modelContext.executeTool(tool, '{"input":"hello"}');
+    expect(result).toBe('result');
+    expect(executeFn).toHaveBeenCalledWith({ input: 'hello' }, expect.any(Object));
+  });
+
+  it('should also accept a bare tool name and object args (convenience)', async () => {
+    const executeFn = vi.fn().mockResolvedValue('result');
+    modelContext.registerTool({
+      name: 'test_tool',
+      description: 'd',
+      inputSchema: { type: 'object', properties: { input: { type: 'string' } } },
+      execute: executeFn,
+    });
+
+    const result = await modelContext.executeTool('test_tool', { input: 'hello' });
+    expect(result).toBe('result');
+    expect(executeFn).toHaveBeenCalledWith({ input: 'hello' }, expect.any(Object));
+  });
+
+  it('should reject for unknown tools', async () => {
+    await expect(modelContext.executeTool('nope', '{}')).rejects.toThrow(/not found/);
   });
 });
 
 describe('WebMCP Polyfill - agent context in execute', () => {
-  let dom: JSDOM;
-  let window: Window & typeof globalThis;
   let modelContext: any;
-  let modelContextTesting: any;
 
   beforeEach(() => {
-    dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
-      url: 'https://example.com',
-      runScripts: 'dangerously',
-    });
-
-    window = dom.window as any;
-    global.window = window as any;
-
-    const polyfillCode = fs.readFileSync(
-      path.join(__dirname, '../src/content-scripts/webmcp-polyfill.js'),
-      'utf8'
-    );
-
-    const script = dom.window.document.createElement('script');
-    script.textContent = polyfillCode;
-    dom.window.document.body.appendChild(script);
-    // Polyfill defers registration to DOMContentLoaded (installed at document_start in prod)
-    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
-
-    modelContext = (window as any).navigator.modelContext;
-    modelContextTesting = (window as any).navigator.modelContextTesting;
+    ({ modelContext } = loadPolyfill());
   });
 
   it('should pass agent context with requestUserInteraction to execute', async () => {
@@ -462,7 +293,7 @@ describe('WebMCP Polyfill - agent context in execute', () => {
 
     modelContext.registerTool({
       name: 'test_tool',
-      description: 'Test tool',
+      description: 'd',
       inputSchema: { type: 'object', properties: {} },
       execute: (_args: any, agent: any) => {
         receivedAgent = agent;
@@ -470,7 +301,7 @@ describe('WebMCP Polyfill - agent context in execute', () => {
       },
     });
 
-    await modelContextTesting.executeTool('test_tool', '{}');
+    await modelContext.executeTool('test_tool', '{}');
 
     expect(receivedAgent).toBeDefined();
     expect(typeof receivedAgent.requestUserInteraction).toBe('function');
@@ -481,7 +312,7 @@ describe('WebMCP Polyfill - agent context in execute', () => {
 
     modelContext.registerTool({
       name: 'test_tool',
-      description: 'Test tool',
+      description: 'd',
       inputSchema: { type: 'object', properties: {} },
       execute: async (_args: any, agent: any) => {
         const result = await agent.requestUserInteraction(async () => {
@@ -492,132 +323,21 @@ describe('WebMCP Polyfill - agent context in execute', () => {
       },
     });
 
-    const result = await modelContextTesting.executeTool('test_tool', '{}');
+    const result = await modelContext.executeTool('test_tool', '{}');
 
     expect(interactionCalled).toBe(true);
     expect(result.result).toBe('user_confirmed');
   });
 });
 
-describe('WebMCP Polyfill - provideContext tolerance', () => {
-  let dom: JSDOM;
-  let window: Window & typeof globalThis;
-  let modelContext: any;
-  let modelContextTesting: any;
-
-  beforeEach(() => {
-    dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
-      url: 'https://example.com',
-      runScripts: 'dangerously',
-    });
-
-    window = dom.window as any;
-    global.window = window as any;
-
-    const polyfillCode = fs.readFileSync(
-      path.join(__dirname, '../src/content-scripts/webmcp-polyfill.js'),
-      'utf8'
-    );
-
-    const script = dom.window.document.createElement('script');
-    script.textContent = polyfillCode;
-    dom.window.document.body.appendChild(script);
-    // Polyfill defers registration to DOMContentLoaded (installed at document_start in prod)
-    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
-
-    modelContext = (window as any).navigator.modelContext;
-    modelContextTesting = (window as any).navigator.modelContextTesting;
-  });
-
-  it('should accept provideContext({}) — empty object clears tools', () => {
-    // Pre-register a tool
-    modelContext.registerTool({
-      name: 'existing',
-      description: 'Existing tool',
-      inputSchema: { type: 'object', properties: {} },
-      execute: vi.fn(),
-    });
-    expect(modelContextTesting.listTools().length).toBe(1);
-
-    // Empty context should clear tools, not throw
-    modelContext.provideContext({});
-    expect(modelContextTesting.listTools().length).toBe(0);
-  });
-
-  it('should accept provideContext({context: [...]}) — Shopify compat, ignores unknown fields', () => {
-    // Shopify adapter passes {context: [...]} instead of {tools: [...]}
-    expect(() => {
-      modelContext.provideContext({ context: [{ type: 'text', text: 'some context' }] });
-    }).not.toThrow();
-    expect(modelContextTesting.listTools().length).toBe(0);
-  });
-
-  it('should still throw on provideContext(null)', () => {
-    expect(() => {
-      modelContext.provideContext(null);
-    }).toThrow(/provideContext requires an object argument/);
-  });
-
-  it('should still throw on provideContext() — no argument', () => {
-    expect(() => {
-      modelContext.provideContext();
-    }).toThrow(/provideContext requires an object argument/);
-  });
-
-  it('should still throw on provideContext("string")', () => {
-    expect(() => {
-      modelContext.provideContext('tools');
-    }).toThrow(/provideContext requires an object argument/);
-  });
-
-  it('should work normally with provideContext({tools: [...]}) — standard path', () => {
-    modelContext.provideContext({
-      tools: [
-        {
-          name: 'tool_a',
-          description: 'Tool A',
-          inputSchema: { type: 'object', properties: {} },
-          execute: vi.fn(),
-        },
-      ],
-    });
-    const tools = modelContextTesting.listTools();
-    expect(tools.length).toBe(1);
-    expect(tools[0].name).toBe('tool_a');
-  });
-});
-
 describe('WebMCP Polyfill - annotations', () => {
-  let dom: JSDOM;
-  let window: Window & typeof globalThis;
   let modelContext: any;
-  let modelContextTesting: any;
 
   beforeEach(() => {
-    dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
-      url: 'https://example.com',
-      runScripts: 'dangerously',
-    });
-
-    window = dom.window as any;
-    global.window = window as any;
-
-    const polyfillCode = fs.readFileSync(
-      path.join(__dirname, '../src/content-scripts/webmcp-polyfill.js'),
-      'utf8'
-    );
-
-    const script = dom.window.document.createElement('script');
-    script.textContent = polyfillCode;
-    dom.window.document.body.appendChild(script);
-    // Polyfill defers registration to DOMContentLoaded (installed at document_start in prod)
-    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
-
-    modelContext = (window as any).navigator.modelContext;
-    modelContextTesting = (window as any).navigator.modelContextTesting;
+    ({ modelContext } = loadPolyfill());
   });
 
-  it('registerTool with annotations — survives round-trip via listTools', () => {
+  it('registerTool with annotations — survives round-trip via getTools', async () => {
     modelContext.registerTool({
       name: 'annotated_tool',
       description: 'Tool with annotations',
@@ -626,38 +346,12 @@ describe('WebMCP Polyfill - annotations', () => {
       annotations: { readOnlyHint: true, destructiveHint: false },
     });
 
-    const tools = modelContextTesting.listTools();
+    const tools = await modelContext.getTools();
     expect(tools.length).toBe(1);
     expect(tools[0].annotations).toEqual({ readOnlyHint: true, destructiveHint: false });
   });
 
-  it('provideContext with annotated tools — listTools includes annotations', () => {
-    modelContext.provideContext({
-      tools: [
-        {
-          name: 'safe_tool',
-          description: 'A safe tool',
-          inputSchema: { type: 'object', properties: {} },
-          execute: vi.fn(),
-          annotations: { readOnlyHint: true },
-        },
-        {
-          name: 'dangerous_tool',
-          description: 'A dangerous tool',
-          inputSchema: { type: 'object', properties: {} },
-          execute: vi.fn(),
-          annotations: { destructiveHint: true, idempotentHint: false },
-        },
-      ],
-    });
-
-    const tools = modelContextTesting.listTools();
-    expect(tools.length).toBe(2);
-    expect(tools[0].annotations).toEqual({ readOnlyHint: true });
-    expect(tools[1].annotations).toEqual({ destructiveHint: true, idempotentHint: false });
-  });
-
-  it('tool without annotations — listTools omits the field entirely', () => {
+  it('tool without annotations — getTools omits the field entirely', async () => {
     modelContext.registerTool({
       name: 'plain_tool',
       description: 'No annotations',
@@ -665,40 +359,16 @@ describe('WebMCP Polyfill - annotations', () => {
       execute: vi.fn(),
     });
 
-    const tools = modelContextTesting.listTools();
-    expect(tools.length).toBe(1);
-    expect(tools[0]).not.toHaveProperty('annotations');
+    const [tool] = await modelContext.getTools();
+    expect(tool).not.toHaveProperty('annotations');
   });
 });
 
 describe('WebMCP Polyfill - JSON Schema Validation', () => {
-  let dom: JSDOM;
-  let window: Window & typeof globalThis;
   let agent: any;
 
   beforeEach(() => {
-    dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
-      url: 'https://example.com',
-      runScripts: 'dangerously',
-    });
-
-    window = dom.window as any;
-    global.window = window as any;
-
-    // Load the polyfill
-    const polyfillCode = fs.readFileSync(
-      path.join(__dirname, '../src/content-scripts/webmcp-polyfill.js'),
-      'utf8'
-    );
-
-    const script = dom.window.document.createElement('script');
-    script.textContent = polyfillCode;
-    dom.window.document.body.appendChild(script);
-    // Polyfill defers registration to DOMContentLoaded (installed at document_start in prod)
-    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
-
-    // Use window.agent (backward compat API with both page-side and agent-side methods)
-    agent = (window as any).agent;
+    ({ agent } = loadPolyfill());
   });
 
   // Helper to check validation errors
@@ -739,7 +409,7 @@ describe('WebMCP Polyfill - JSON Schema Validation', () => {
       agent.registerTool(tool);
 
       // Valid params - should pass
-      await agent.callTool('test', {
+      await agent.executeTool('test', {
         name: 'John Doe',
         age: 30,
         active: true,
@@ -747,13 +417,13 @@ describe('WebMCP Polyfill - JSON Schema Validation', () => {
 
       // Missing required field - should fail
       await expectValidationError(
-        () => agent.callTool('test', { age: 30, active: true }),
+        () => agent.executeTool('test', { age: 30, active: true }),
         ['name: required field missing']
       );
 
       // Wrong type - should fail
       await expectValidationError(
-        () => agent.callTool('test', { name: 123, age: 30 }),
+        () => agent.executeTool('test', { name: 123, age: 30 }),
         ['name: expected string, got number']
       );
     });
@@ -775,14 +445,14 @@ describe('WebMCP Polyfill - JSON Schema Validation', () => {
       agent.registerTool(tool);
 
       // Valid integers and numbers
-      await agent.callTool('test', {
+      await agent.executeTool('test', {
         count: 5,
         price: 19.99,
       });
 
       // Float for integer field - should fail
       await expectValidationError(
-        () => agent.callTool('test', { count: 5.5, price: 19.99 }),
+        () => agent.executeTool('test', { count: 5.5, price: 19.99 }),
         ['count: expected integer']
       );
     });
@@ -821,7 +491,7 @@ describe('WebMCP Polyfill - JSON Schema Validation', () => {
       agent.registerTool(tool);
 
       // Valid nested object - should pass
-      await agent.callTool('test', {
+      await agent.executeTool('test', {
         user: {
           name: 'Jane Smith',
           email: 'jane@example.com',
@@ -835,7 +505,7 @@ describe('WebMCP Polyfill - JSON Schema Validation', () => {
       // Missing nested required field - should fail with path
       await expectValidationError(
         () =>
-          agent.callTool('test', {
+          agent.executeTool('test', {
             user: {
               name: 'Jane Smith',
               // Missing email
@@ -850,7 +520,7 @@ describe('WebMCP Polyfill - JSON Schema Validation', () => {
       // Missing deeply nested required field - should fail with full path
       await expectValidationError(
         () =>
-          agent.callTool('test', {
+          agent.executeTool('test', {
             user: {
               name: 'Jane Smith',
               email: 'jane@example.com',
@@ -889,7 +559,7 @@ describe('WebMCP Polyfill - JSON Schema Validation', () => {
       agent.registerTool(tool);
 
       // Valid arrays - should pass
-      await agent.callTool('test', {
+      await agent.executeTool('test', {
         tags: ['javascript', 'typescript', 'react'],
         scores: [95, 87, 92],
       });
@@ -897,7 +567,7 @@ describe('WebMCP Polyfill - JSON Schema Validation', () => {
       // Wrong item type - should fail with index
       await expectValidationError(
         () =>
-          agent.callTool('test', {
+          agent.executeTool('test', {
             tags: ['javascript', 123, 'react'],
             scores: [95, 87, 92],
           }),
@@ -932,7 +602,7 @@ describe('WebMCP Polyfill - JSON Schema Validation', () => {
       agent.registerTool(tool);
 
       // Valid array of objects - should pass
-      await agent.callTool('test', {
+      await agent.executeTool('test', {
         add_items: [
           {
             product_id: 'gid://shopify/ProductVariant/123',
@@ -948,7 +618,7 @@ describe('WebMCP Polyfill - JSON Schema Validation', () => {
       // Wrong type in array item - should fail with path
       await expectValidationError(
         () =>
-          agent.callTool('test', {
+          agent.executeTool('test', {
             add_items: [
               {
                 product_id: 'gid://shopify/ProductVariant/123',
@@ -962,7 +632,7 @@ describe('WebMCP Polyfill - JSON Schema Validation', () => {
       // Missing required field in array item - should fail with path
       await expectValidationError(
         () =>
-          agent.callTool('test', {
+          agent.executeTool('test', {
             add_items: [
               {
                 product_id: 'gid://shopify/ProductVariant/123',
@@ -1022,7 +692,7 @@ describe('WebMCP Polyfill - JSON Schema Validation', () => {
       agent.registerTool(tool);
 
       // Valid deeply nested structure - should pass
-      await agent.callTool('test', {
+      await agent.executeTool('test', {
         company: {
           name: 'TechCorp',
           departments: [
@@ -1052,7 +722,7 @@ describe('WebMCP Polyfill - JSON Schema Validation', () => {
       // Missing deeply nested field - should fail with full path
       await expectValidationError(
         () =>
-          agent.callTool('test', {
+          agent.executeTool('test', {
             company: {
               name: 'TechCorp',
               departments: [
@@ -1092,7 +762,7 @@ describe('WebMCP Polyfill - JSON Schema Validation', () => {
       agent.registerTool(tool);
 
       // Extra properties should be allowed
-      await agent.callTool('test', {
+      await agent.executeTool('test', {
         name: 'John',
         extra: 'field',
         another: 123,
@@ -1118,7 +788,7 @@ describe('WebMCP Polyfill - JSON Schema Validation', () => {
       // Extra properties should be rejected
       await expectValidationError(
         () =>
-          agent.callTool('test', {
+          agent.executeTool('test', {
             name: 'John',
             extra: 'field',
           }),
@@ -1183,7 +853,7 @@ describe('WebMCP Polyfill - JSON Schema Validation', () => {
       agent.registerTool(tool);
 
       // Valid Shopify params - should pass
-      await agent.callTool('shopify_update_cart', {
+      await agent.executeTool('shopify_update_cart', {
         add_items: [
           {
             product_id: 'gid://shopify/ProductVariant/30674260033616',
@@ -1193,7 +863,7 @@ describe('WebMCP Polyfill - JSON Schema Validation', () => {
       });
 
       // Complex valid params - should pass
-      await agent.callTool('shopify_update_cart', {
+      await agent.executeTool('shopify_update_cart', {
         cart_id: 'cart123',
         add_items: [
           {
@@ -1218,7 +888,7 @@ describe('WebMCP Polyfill - JSON Schema Validation', () => {
       // Missing required nested field - should fail with path
       await expectValidationError(
         () =>
-          agent.callTool('shopify_update_cart', {
+          agent.executeTool('shopify_update_cart', {
             buyer_identity: {
               delivery_address: {
                 address1: '123 Main St',
@@ -1260,7 +930,7 @@ describe('WebMCP Polyfill - JSON Schema Validation', () => {
       agent.registerTool(tool);
 
       try {
-        await agent.callTool('test', {
+        await agent.executeTool('test', {
           users: [
             { name: 'Alice', age: 30 },
             { age: 'twenty-five' }, // Missing name, wrong type


### PR DESCRIPTION
A few things about the API shape have changed in Chromium 150, and the polyfill was out of date with those.

This PR brings the polyfill up to date with the latest API shape:
* The methods formerly on `navigator.modelContextForTesting` are now available on `document.modelContext`
* `navigator.modelContext` is now `document.modelContext`