### PR TITLE
Fix WebMCP bridge to read from document.modelContext

### DIFF
--- a/src/content-scripts/page-bridge.js
+++ b/src/content-scripts/page-bridge.js
@@ -28,21 +28,51 @@
 
   /**
    * Get the agent-side API for discovering and executing tools
-   * 
-   * Chrome's WebMCP implementation:
-   * - navigator.modelContextTesting = agent-side (listTools, executeTool, registerToolsChangedCallback)
-   * - navigator.modelContext = page-side (registerTool, unregisterTool, provideContext)
-   * 
-   * Our polyfill provides the same separation.
+   *
+   * Per W3C WebMCP spec PR #184 (merged May 27, 2026), the `modelContext` API moved
+   * from `Navigator` to `Document`. Chrome 150+ ships a unified `document.modelContext`
+   * with both page-side (registerTool/unregisterTool) and agent-side (getTools/executeTool)
+   * methods. `navigator.modelContext` / `navigator.modelContextTesting` are deprecated.
+   *
+   * Resolution priority (spec-canonical first):
+   *   1. document.modelContext (native, Chrome 150+) — getTools() returns a Promise
+   *   2. navigator.modelContextTesting (polyfill or old native) — listTools() is sync
+   *   3. window.agent (legacy compat)
+   *
+   * `listTools` is normalized to ALWAYS return a Promise so callers can `await` it
+   * regardless of which surface was found.
    */
   function getAgentAPI() {
-    // Use modelContextTesting (agent-side API) - either native Chrome or our polyfill
+    // 1. document.modelContext (W3C spec PR #184, Chrome 150+) — canonical unified surface
+    const dmc = document.modelContext;
+    if (dmc && typeof dmc.getTools === 'function') {
+      return {
+        native: true,
+        // getTools() returns a Promise; normalize just in case a future impl is sync
+        listTools: () => Promise.resolve(dmc.getTools()),
+        // Native executeTool(name, args) takes args as an object (not a JSON string)
+        executeTool: (name, args) => dmc.executeTool(name, args),
+        registerToolsChangedCallback: (callback) => {
+          if ('ontoolchange' in dmc) {
+            dmc.ontoolchange = callback;
+          } else if (typeof dmc.registerToolsChangedCallback === 'function') {
+            // Fallback for older native builds predating ontoolchange
+            dmc.registerToolsChangedCallback(callback);
+          } else {
+            console.warn('[WebMCP Bridge] No tools-changed callback mechanism on document.modelContext');
+          }
+        }
+      };
+    }
+
+    // 2. navigator.modelContextTesting (polyfill or old native) — agent-side API
     if ('modelContextTesting' in navigator) {
       const mct = navigator.modelContextTesting;
       const isNative = !Object.prototype.hasOwnProperty.call(mct, 'errors'); // Native won't have our errors property
       return {
         native: isNative,
-        listTools: () => mct.listTools(),
+        // listTools() is sync; normalize to a Promise
+        listTools: () => Promise.resolve(mct.listTools()),
         // executeTool expects args as JSON string
         executeTool: (name, args) => mct.executeTool(name, JSON.stringify(args)),
         registerToolsChangedCallback: (callback) => {
@@ -57,11 +87,12 @@
         }
       };
     }
-    // Legacy fallback: window.agent (backward compat API)
+
+    // 3. Legacy fallback: window.agent (backward compat API)
     if ('agent' in window) {
       return {
         native: false,
-        listTools: () => window.agent.listTools(),
+        listTools: () => Promise.resolve(window.agent.listTools()),
         executeTool: (name, args) => window.agent.callTool(name, args),
         registerToolsChangedCallback: (callback) => window.agent.addEventListener('tools/listChanged', callback)
       };
@@ -72,18 +103,25 @@
   /**
    * Initialize bridge using the agent-side API
    */
-  function initBridge() {
+  async function initBridge() {
     const agentAPI = getAgentAPI();
 
     if (!agentAPI) {
-      console.warn('[WebMCP Bridge] No WebMCP API found (modelContextTesting, modelContext, or agent)');
+      console.warn('[WebMCP Bridge] No WebMCP API found (document.modelContext, modelContextTesting, or agent)');
       return;
     }
 
     console.log('[WebMCP Bridge] Initializing in MAIN world', agentAPI.native ? '(native Chrome API)' : '(polyfill)');
 
-    // Get current tools immediately - in case any were registered before we got here
-    const currentTools = agentAPI.listTools();
+    // Get current tools immediately - in case any were registered before we got here.
+    // listTools() is async (document.modelContext.getTools() returns a Promise).
+    let currentTools;
+    try {
+      currentTools = await agentAPI.listTools();
+    } catch (err) {
+      console.error('[WebMCP Bridge] Failed to list tools on init:', err);
+      currentTools = [];
+    }
     console.log('[WebMCP Bridge] Current tools on init:', currentTools);
 
     // Send initial snapshot if there are already tools
@@ -102,9 +140,9 @@
     }
 
     // Subscribe to tool registry changes
-    agentAPI.registerToolsChangedCallback(() => {
+    agentAPI.registerToolsChangedCallback(async () => {
       try {
-        const tools = agentAPI.listTools();
+        const tools = await agentAPI.listTools();
         postToExtension({
           jsonrpc: JSONRPC,
           method: 'tools/listChanged',
@@ -139,7 +177,7 @@
         console.log('[WebMCP Bridge] Received tools/list request');
 
         try {
-          const tools = agentAPI.listTools();
+          const tools = await agentAPI.listTools();
 
           // Send tools via notification (not a response to preserve protocol semantics)
           postToExtension({

--- a/src/content-scripts/webmcp-polyfill.js
+++ b/src/content-scripts/webmcp-polyfill.js
@@ -15,9 +15,12 @@
 (function () {
   'use strict';
 
-  // Guard: already initialized (either by us or native browser support)
+  // Guard: already initialized (either by us or native browser support).
+  // Per W3C spec PR #184, Chrome 150+ exposes native `document.modelContext`; in
+  // older builds native `navigator.modelContext` may be present. Either means a
+  // native surface already owns the tool store, so we skip our polyfill.
   if ('modelContext' in navigator || 'modelContext' in document) {
-    console.log('[WebMCP] Native navigator.modelContext detected, skipping polyfill');
+    console.log('[WebMCP] Native modelContext detected (document.modelContext or navigator.modelContext), skipping polyfill');
     // Still set up window.agent alias for backward compat if not present
     if (!('agent' in window)) {
       Object.defineProperty(window, 'agent', {

--- a/src/content-scripts/webmcp-polyfill.js
+++ b/src/content-scripts/webmcp-polyfill.js
@@ -311,6 +311,49 @@
   }
 
   /**
+   * Returns the browser's native document.modelContext if it has appeared.
+   *
+   * W3C WebMCP spec PR #184 moved modelContext from Navigator to Document.
+   * Chrome 150+ initializes native `document.modelContext` AFTER document_start,
+   * so when this polyfill runs it is not yet present and we install our own
+   * navigator.modelContext/modelContextTesting with a separate tool store.
+   * When the native surface shows up later, tools registered through our
+   * polyfill (via window.agent / navigator.modelContext, e.g. AgentBoard's
+   * compiled and user 'use webmcp-tool v1' scripts) would otherwise be
+   * invisible to agents reading the canonical document.modelContext.
+   *
+   * This polyfill never installs document.modelContext, so any
+   * document.modelContext present is the native implementation.
+   */
+  function getNativeDocumentModelContext() {
+    const native = document.modelContext;
+    if (native && native !== modelContext && typeof native.registerTool === 'function') {
+      return native;
+    }
+    return null;
+  }
+
+  /**
+   * Forward an additive page-side mutation to the native document.modelContext
+   * (Chrome 150+) so tools registered through the polyfill are also visible on
+   * the spec-canonical surface. Swallows errors so a native rejection never
+   * breaks polyfill callers.
+   *
+   * Note: provideContext/clearContext are intentionally NOT forwarded — they
+   * are destructive replace/clear operations and forwarding them would clobber
+   * site-registered tools in the native store. Only additive single-tool
+   * operations (register/unregister) are mirrored.
+   */
+  function forwardToNative(fn) {
+    try {
+      const native = getNativeDocumentModelContext();
+      if (native) fn(native);
+    } catch (e) {
+      console.warn('[WebMCP] Failed to forward to native document.modelContext:', e);
+    }
+  }
+
+  /**
    * PAGE-SIDE API: navigator.modelContext
    * For pages to register tools with the agent
    */
@@ -338,7 +381,9 @@
 
     /**
      * Register a single tool (per WebMCP spec)
-     * Adds to existing tools without clearing
+     * Adds to existing tools without clearing. Also forwards to the native
+     * document.modelContext (Chrome 150+) so the tool is discoverable via the
+     * spec-canonical surface.
      */
     registerTool(rawTool) {
       const tool = validateAndNormalizeTool(rawTool);
@@ -348,10 +393,12 @@
       }
       tools.set(tool.name, tool);
       queueMicrotask(() => events.dispatchEvent({ type: 'tools/listChanged' }));
+      forwardToNative((native) => native.registerTool(rawTool));
     },
 
     /**
      * Unregister a tool by name (per WebMCP spec)
+     * Also forwards to the native document.modelContext (Chrome 150+).
      */
     unregisterTool(toolName) {
       if (typeof toolName !== 'string') {
@@ -360,6 +407,7 @@
       const existed = tools.delete(toolName);
       if (existed) {
         queueMicrotask(() => events.dispatchEvent({ type: 'tools/listChanged' }));
+        forwardToNative((native) => native.unregisterTool(toolName));
       }
       return existed;
     },

--- a/tests/webmcp-page-bridge.test.ts
+++ b/tests/webmcp-page-bridge.test.ts
@@ -1,0 +1,412 @@
+/**
+ * Tests for the WebMCP Page Bridge (MAIN world)
+ *
+ * Verifies the bridge aligns with W3C WebMCP spec PR #184, which moved
+ * `modelContext` from `Navigator` to `Document` (Chrome 150+):
+ *   - Tools registered on `document.modelContext` (native) are visible to the bridge
+ *   - The bridge prefers `document.modelContext` over `navigator.modelContextTesting`
+ *   - Fallback to `navigator.modelContextTesting` still works when
+ *     `document.modelContext` is absent
+ *   - `document.modelContext.getTools()` (Promise) and `modelContextTesting.listTools()`
+ *     (sync) are both handled via Promise normalization
+ *
+ * Note on JSDOM: same-window `postMessage` produces a MessageEvent whose
+ * `source` is `null` in JSDOM (in real browsers it is the originating window).
+ * The bridge filters incoming messages with `event.source !== window`, so to
+ * feed requests to the bridge we dispatch synthetic MessageEvents with
+ * `source: window`. Outgoing bridge messages are captured by spying on
+ * `window.postMessage` (the bridge's only outbound channel).
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+// @ts-ignore - jsdom types not installed
+import { JSDOM } from 'jsdom';
+import fs from 'fs';
+import path from 'path';
+
+const BRIDGE_CODE = fs.readFileSync(
+  path.join(__dirname, '../src/content-scripts/page-bridge.js'),
+  'utf8'
+);
+
+const JSONRPC = '2.0';
+
+/** Inject the page-bridge IIFE into a JSDOM. */
+function loadBridge(dom: JSDOM): void {
+  const script = dom.window.document.createElement('script');
+  script.textContent = BRIDGE_CODE;
+  dom.window.document.body.appendChild(script);
+}
+
+interface Harness {
+  dom: JSDOM;
+  window: any;
+  outbox: any[]; // messages posted by the bridge (source === 'webmcp-main')
+  sendToBridge: (msg: any) => void; // deliver a request to the bridge
+}
+
+function harness(): Harness {
+  const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+    url: 'https://example.com',
+    runScripts: 'dangerously',
+  });
+  const window = dom.window as any;
+  global.window = window as any;
+
+  const outbox: any[] = [];
+  // Spy on the bridge's only outbound channel
+  window.postMessage = (data: any) => {
+    outbox.push(data);
+  };
+
+  // Deliver an inbound request to the bridge with a correct `source` so the
+  // bridge's `event.source === window` filter accepts it.
+  const sendToBridge = (msg: any) => {
+    const ev = new window.MessageEvent('message', { data: msg, source: window });
+    window.dispatchEvent(ev);
+  };
+
+  return { dom, window, outbox, sendToBridge };
+}
+
+/** Wait a tick for async bridge init / microtasks to settle. */
+function flush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/**
+ * Build a fake native document.modelContext (Chrome 150+ unified surface).
+ * getTools() returns a Promise; ontoolchange is the change handler.
+ */
+function makeNativeDocumentModelContext(initialTools: any[] = []) {
+  const store = new Map<string, any>();
+  for (const t of initialTools) store.set(t.name, t);
+
+  let ontoolchange: ((...args: any[]) => void) | null = null;
+
+  const mc = {
+    registerTool(tool: any) {
+      store.set(tool.name, tool);
+      if (ontoolchange) ontoolchange();
+    },
+    unregisterTool(name: string) {
+      const existed = store.delete(name);
+      if (existed && ontoolchange) ontoolchange();
+      return existed;
+    },
+    getTools() {
+      return Promise.resolve(
+        Array.from(store.values()).map(({ name, description, inputSchema }) => ({
+          name,
+          description,
+          inputSchema,
+        }))
+      );
+    },
+    async executeTool(name: string, args: any) {
+      const tool = store.get(name);
+      if (!tool) throw new Error(`Tool '${name}' not found`);
+      return tool.execute(args, {});
+    },
+    get ontoolchange() {
+      return ontoolchange;
+    },
+    set ontoolchange(cb: ((...args: any[]) => void) | null) {
+      ontoolchange = cb;
+    },
+  };
+
+  return mc;
+}
+
+/**
+ * Build a fake navigator.modelContextTesting (polyfill / old native agent-side).
+ * listTools() is synchronous.
+ */
+function makeModelContextTesting(initialTools: any[] = []) {
+  const tools = [...initialTools];
+  let ontoolchange: ((...args: any[]) => void) | null = null;
+  const callbacks: Array<(...args: any[]) => void> = [];
+
+  const mct = {
+    listTools() {
+      return tools.map(({ name, description, inputSchema }) => ({
+        name,
+        description,
+        inputSchema,
+      }));
+    },
+    async executeTool(name: string, args: string) {
+      const tool = tools.find((t) => t.name === name);
+      if (!tool) throw new Error(`Tool '${name}' not found`);
+      return tool.execute(typeof args === 'string' ? JSON.parse(args) : args, {});
+    },
+    registerToolsChangedCallback(cb: (...args: any[]) => void) {
+      callbacks.push(cb);
+    },
+    get ontoolchange() {
+      return ontoolchange;
+    },
+    set ontoolchange(cb: ((...args: any[]) => void) | null) {
+      ontoolchange = cb;
+    },
+  };
+  return mct;
+}
+
+describe('WebMCP Page Bridge - document.modelContext (spec PR #184)', () => {
+  let h: Harness;
+  let nativeMC: any;
+
+  beforeEach(() => {
+    h = harness();
+  });
+
+  it('sees tools registered on document.modelContext (native) via getTools()', async () => {
+    nativeMC = makeNativeDocumentModelContext([
+      {
+        name: 'site_tool',
+        description: 'A tool registered by the page',
+        inputSchema: { type: 'object', properties: {} },
+        execute: vi.fn(),
+      },
+    ]);
+    Object.defineProperty(h.window.document, 'modelContext', {
+      value: nativeMC,
+      configurable: true,
+      enumerable: true,
+    });
+
+    loadBridge(h.dom);
+    await flush();
+
+    const snapshot = h.outbox.find((m) => m.method === 'tools/listChanged' && m.params?.initial);
+    expect(snapshot).toBeDefined();
+    expect(snapshot.params.tools).toHaveLength(1);
+    expect(snapshot.params.tools[0].name).toBe('site_tool');
+  });
+
+  it('prefers document.modelContext over navigator.modelContextTesting', async () => {
+    nativeMC = makeNativeDocumentModelContext([
+      { name: 'native_tool', description: 'n', inputSchema: {}, execute: vi.fn() },
+    ]);
+    Object.defineProperty(h.window.document, 'modelContext', {
+      value: nativeMC,
+      configurable: true,
+      enumerable: true,
+    });
+
+    // Also provide the deprecated agent-side surface with a DIFFERENT tool
+    const mct = makeModelContextTesting([
+      { name: 'polyfill_tool', description: 'p', inputSchema: {}, execute: vi.fn() },
+    ]);
+    Object.defineProperty(h.window.navigator, 'modelContextTesting', {
+      value: mct,
+      configurable: true,
+      enumerable: true,
+    });
+    const listToolsSpy = vi.spyOn(mct, 'listTools');
+
+    loadBridge(h.dom);
+    await flush();
+
+    expect(listToolsSpy).not.toHaveBeenCalled();
+    const snapshot = h.outbox.find((m) => m.params?.initial);
+    expect(snapshot).toBeDefined();
+    expect(snapshot.params.tools.map((t: any) => t.name)).toEqual(['native_tool']);
+  });
+
+  it('forwards tool changes via document.modelContext.ontoolchange', async () => {
+    nativeMC = makeNativeDocumentModelContext([]);
+    Object.defineProperty(h.window.document, 'modelContext', {
+      value: nativeMC,
+      configurable: true,
+      enumerable: true,
+    });
+
+    loadBridge(h.dom);
+    await flush();
+
+    // No tools at init => no initial snapshot
+    expect(h.outbox.find((m) => m.params?.initial)).toBeUndefined();
+
+    // A site registers a tool later; native fires ontoolchange
+    nativeMC.registerTool({
+      name: 'late_tool',
+      description: 'Registered after bridge init',
+      inputSchema: { type: 'object', properties: {} },
+      execute: vi.fn(),
+    });
+    await flush();
+
+    const changeMsg = h.outbox.find((m) => m.method === 'tools/listChanged' && !m.params?.initial);
+    expect(changeMsg).toBeDefined();
+    expect(changeMsg.params.tools.map((t: any) => t.name)).toEqual(['late_tool']);
+  });
+
+  it('routes tools/call to document.modelContext.executeTool with args as an object', async () => {
+    const execSpy = vi.fn(async (args: any) => ({ echoed: args }));
+    nativeMC = makeNativeDocumentModelContext([
+      { name: 'echo', description: 'echo', inputSchema: {}, execute: execSpy },
+    ]);
+    Object.defineProperty(h.window.document, 'modelContext', {
+      value: nativeMC,
+      configurable: true,
+      enumerable: true,
+    });
+
+    loadBridge(h.dom);
+    await flush();
+
+    h.sendToBridge({
+      source: 'webmcp-bridge',
+      jsonrpc: JSONRPC,
+      id: 'call-1',
+      method: 'tools/call',
+      params: { name: 'echo', arguments: { x: 1 } },
+    });
+    await flush();
+
+    expect(execSpy).toHaveBeenCalledTimes(1);
+    // Native executeTool receives args as an object, NOT a JSON string
+    expect(execSpy.mock.calls[0][0]).toEqual({ x: 1 });
+
+    const response = h.outbox.find((m) => m.id === 'call-1' && m.result !== undefined);
+    expect(response).toBeDefined();
+    expect(response.result).toEqual({ echoed: { x: 1 } });
+  });
+
+  it('responds to tools/list requests via document.modelContext.getTools()', async () => {
+    nativeMC = makeNativeDocumentModelContext([
+      { name: 't1', description: 't1', inputSchema: {}, execute: vi.fn() },
+    ]);
+    Object.defineProperty(h.window.document, 'modelContext', {
+      value: nativeMC,
+      configurable: true,
+      enumerable: true,
+    });
+
+    loadBridge(h.dom);
+    await flush();
+
+    h.sendToBridge({
+      source: 'webmcp-bridge',
+      jsonrpc: JSONRPC,
+      id: 'list-1',
+      method: 'tools/list',
+      params: {},
+    });
+    await flush();
+
+    const requested = h.outbox.find((m) => m.params?.requested === true);
+    expect(requested).toBeDefined();
+    expect(requested.params.tools.map((t: any) => t.name)).toEqual(['t1']);
+  });
+});
+
+describe('WebMCP Page Bridge - fallback to navigator.modelContextTesting', () => {
+  let h: Harness;
+
+  beforeEach(() => {
+    h = harness();
+  });
+
+  it('falls back to navigator.modelContextTesting when document.modelContext is absent', async () => {
+    const mct = makeModelContextTesting([
+      { name: 'fallback_tool', description: 'fb', inputSchema: {}, execute: vi.fn() },
+    ]);
+    Object.defineProperty(h.window.navigator, 'modelContextTesting', {
+      value: mct,
+      configurable: true,
+      enumerable: true,
+    });
+
+    loadBridge(h.dom);
+    await flush();
+
+    const snapshot = h.outbox.find((m) => m.params?.initial);
+    expect(snapshot).toBeDefined();
+    expect(snapshot.params.tools.map((t: any) => t.name)).toEqual(['fallback_tool']);
+  });
+
+  it('passes args as a JSON string to modelContextTesting.executeTool (legacy contract)', async () => {
+    const execSpy = vi.fn(async (args: any) => ({ got: args }));
+    const mct = makeModelContextTesting([
+      { name: 'echo', description: 'echo', inputSchema: {}, execute: execSpy },
+    ]);
+    Object.defineProperty(h.window.navigator, 'modelContextTesting', {
+      value: mct,
+      configurable: true,
+      enumerable: true,
+    });
+    // Spy on the agent-side executeTool to inspect the raw arg contract
+    const executeToolSpy = vi.spyOn(mct, 'executeTool');
+
+    loadBridge(h.dom);
+    await flush();
+
+    h.sendToBridge({
+      source: 'webmcp-bridge',
+      jsonrpc: JSONRPC,
+      id: 'call-2',
+      method: 'tools/call',
+      params: { name: 'echo', arguments: { x: 2 } },
+    });
+    await flush();
+
+    expect(executeToolSpy).toHaveBeenCalledTimes(1);
+    // modelContextTesting.executeTool receives args as a JSON STRING
+    expect(typeof executeToolSpy.mock.calls[0][1]).toBe('string');
+    expect(JSON.parse(executeToolSpy.mock.calls[0][1])).toEqual({ x: 2 });
+
+    const response = h.outbox.find((m) => m.id === 'call-2' && m.result !== undefined);
+    expect(response).toBeDefined();
+    expect(response.result).toEqual({ got: { x: 2 } });
+  });
+
+  it('forwards changes when modelContextTesting.ontoolchange fires with tools present', async () => {
+    const tools: any[] = [];
+    const mct = {
+      listTools: () =>
+        tools.map(({ name, description, inputSchema }) => ({ name, description, inputSchema })),
+      async executeTool() {
+        return {};
+      },
+      registerToolsChangedCallback() {},
+      ontoolchange: null as ((...args: any[]) => void) | null,
+    };
+    Object.defineProperty(h.window.navigator, 'modelContextTesting', {
+      value: mct,
+      configurable: true,
+      enumerable: true,
+    });
+
+    loadBridge(h.dom);
+    await flush();
+
+    // Empty at init => no initial snapshot
+    expect(h.outbox.find((m) => m.params?.initial)).toBeUndefined();
+
+    // A tool appears, then the polyfill fires ontoolchange
+    tools.push({ name: 'chg_tool', description: 'c', inputSchema: {}, execute: vi.fn() });
+    mct.ontoolchange!();
+    await flush();
+
+    const changeMsg = h.outbox.find((m) => m.method === 'tools/listChanged' && !m.params?.initial);
+    expect(changeMsg).toBeDefined();
+    expect(changeMsg.params.tools.map((t: any) => t.name)).toEqual(['chg_tool']);
+  });
+});
+
+describe('WebMCP Page Bridge - no API present', () => {
+  it('logs a warning and posts nothing when no WebMCP surface exists', async () => {
+    const h = harness();
+    const warnSpy = vi.spyOn(h.window.console, 'warn').mockImplementation(() => {});
+
+    loadBridge(h.dom);
+    await flush();
+
+    expect(h.outbox).toHaveLength(0);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});

--- a/tests/webmcp-polyfill.test.ts
+++ b/tests/webmcp-polyfill.test.ts
@@ -1261,3 +1261,175 @@ describe('WebMCP Polyfill - JSON Schema Validation', () => {
     });
   });
 });
+
+describe('WebMCP Polyfill - forwarding to native document.modelContext (spec PR #184)', () => {
+  let dom: JSDOM;
+  let window: Window & typeof globalThis;
+  let modelContext: any;
+  let modelContextTesting: any;
+
+  beforeEach(() => {
+    dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+      url: 'https://example.com',
+      runScripts: 'dangerously',
+    });
+
+    window = dom.window as any;
+    global.window = window as any;
+
+    const polyfillCode = fs.readFileSync(
+      path.join(__dirname, '../src/content-scripts/webmcp-polyfill.js'),
+      'utf8'
+    );
+
+    const script = dom.window.document.createElement('script');
+    script.textContent = polyfillCode;
+    dom.window.document.body.appendChild(script);
+
+    modelContext = (window as any).navigator.modelContext;
+    modelContextTesting = (window as any).navigator.modelContextTesting;
+  });
+
+  /**
+   * Simulate Chrome 150+ native document.modelContext appearing AFTER the
+   * polyfill installed at document_start (the race described in spec PR #184).
+   */
+  function installNativeDocumentModelContext() {
+    const store = new Map<string, any>();
+    const native = {
+      registerTool: vi.fn((tool: any) => store.set(tool.name, tool)),
+      unregisterTool: vi.fn((name: string) => store.delete(name)),
+      getTools: vi.fn(() =>
+        Promise.resolve(
+          Array.from(store.values()).map(({ name, description, inputSchema }) => ({
+            name,
+            description,
+            inputSchema,
+          }))
+        )
+      ),
+      executeTool: vi.fn(async (name: string, args: any) => {
+        const t = store.get(name);
+        return t ? t.execute(args) : undefined;
+      }),
+      ontoolchange: null as any,
+    };
+    Object.defineProperty(window.document, 'modelContext', {
+      value: native,
+      configurable: true,
+      enumerable: true,
+    });
+    return native;
+  }
+
+  it('forwards registerTool to native document.modelContext when it appears later', async () => {
+    const native = installNativeDocumentModelContext();
+
+    modelContext.registerTool({
+      name: 'forwarded_tool',
+      description: 'registered via polyfill',
+      inputSchema: { type: 'object', properties: {} },
+      execute: vi.fn(),
+    });
+
+    expect(native.registerTool).toHaveBeenCalledTimes(1);
+    expect(native.registerTool.mock.calls[0][0].name).toBe('forwarded_tool');
+
+    // The tool is now visible via the native surface
+    const tools = await native.getTools();
+    expect(tools.map((t: any) => t.name)).toContain('forwarded_tool');
+  });
+
+  it('also forwards registrations made via window.agent (user scripts)', async () => {
+    const native = installNativeDocumentModelContext();
+    const agent = (window as any).agent;
+
+    agent.registerTool({
+      name: 'user_script_tool',
+      description: 'from a use webmcp-tool v1 script',
+      inputSchema: { type: 'object', properties: {} },
+      execute: vi.fn(),
+    });
+
+    expect(native.registerTool).toHaveBeenCalledTimes(1);
+    expect(native.registerTool.mock.calls[0][0].name).toBe('user_script_tool');
+  });
+
+  it('forwards unregisterTool to native document.modelContext', async () => {
+    const native = installNativeDocumentModelContext();
+
+    modelContext.registerTool({
+      name: 'temp_tool',
+      description: 'temp',
+      inputSchema: { type: 'object', properties: {} },
+      execute: vi.fn(),
+    });
+    expect(native.registerTool).toHaveBeenCalledTimes(1);
+
+    modelContext.unregisterTool('temp_tool');
+    expect(native.unregisterTool).toHaveBeenCalledTimes(1);
+    expect(native.unregisterTool.mock.calls[0][0]).toBe('temp_tool');
+  });
+
+  it('does NOT forward provideContext (avoids clobbering native site tools)', async () => {
+    const native = installNativeDocumentModelContext();
+
+    // A site already registered a tool on the native store
+    native.registerTool({
+      name: 'site_tool',
+      description: 'from the page',
+      inputSchema: {},
+      execute: vi.fn(),
+    });
+    native.registerTool.mockClear();
+
+    // A user script calls provideContext on the polyfill surface
+    modelContext.provideContext({
+      tools: [
+        {
+          name: 'replace_tool',
+          description: 'replace',
+          inputSchema: { type: 'object', properties: {} },
+          execute: vi.fn(),
+        },
+      ],
+    });
+
+    // provideContext must NOT be forwarded (would wipe site_tool from native)
+    expect(native.registerTool).not.toHaveBeenCalled();
+    const tools = await native.getTools();
+    expect(tools.map((t: any) => t.name)).toEqual(['site_tool']);
+  });
+
+  it('does not forward when there is no native document.modelContext', () => {
+    // No native installed — forwarding should be a no-op (no throw)
+    expect(() =>
+      modelContext.registerTool({
+        name: 'no_native',
+        description: 'no native',
+        inputSchema: { type: 'object', properties: {} },
+        execute: vi.fn(),
+      })
+    ).not.toThrow();
+
+    // Polyfill store still has the tool
+    expect(modelContextTesting.listTools().map((t: any) => t.name)).toContain('no_native');
+  });
+
+  it('keeps the polyfill store in sync independently of native', async () => {
+    const native = installNativeDocumentModelContext();
+
+    modelContext.registerTool({
+      name: 'synced',
+      description: 'in both stores',
+      inputSchema: {},
+      execute: vi.fn(),
+    });
+
+    // Polyfill (modelContextTesting) sees it
+    expect(modelContextTesting.listTools().map((t: any) => t.name)).toContain('synced');
+    // Native sees it (forwarded)
+    const nativeTools = await native.getTools();
+    expect(nativeTools.map((t: any) => t.name)).toContain('synced');
+  });
+});


### PR DESCRIPTION
The W3C WebMCP spec moved `modelContext` from `navigator` to `document` (PR #184, May 2026). Chrome 150 ships this. `document.modelContext` is the canonical surface now, and `navigator.modelContext` is deprecated.

AgentBoard's bridge was still reading tools from `navigator.modelContextTesting`, the old agent-side API. When a site registers tools on `document.modelContext` (which is what spec-compliant sites do now), the bridge doesn't see them. The agent panel shows zero tools. This broke WebMCP discovery on Chrome 150+.

The fix is in two files.

The bridge (`src/content-scripts/page-bridge.js`) now reads from `document.modelContext` first, falling back to `navigator.modelContextTesting` and then `window.agent`. The native `document.modelContext` API is slightly different from the polyfill: `getTools()` returns a Promise instead of a sync array, and `executeTool` takes args as an object instead of a JSON string. The bridge normalizes those differences. The fallbacks are preserved for browsers that don't have native `document.modelContext` yet.

The polyfill (`src/content-scripts/webmcp-polyfill.js`) runs at `document_start`, before Chrome's native `document.modelContext` exists, so it installs its own `navigator.modelContext` with a separate tool store. Without a change there, AgentBoard's own tools (built-ins and user-authored `use webmcp-tool v1` scripts) would be stuck in the polyfill store, invisible to agents reading the native surface. So `registerTool` and `unregisterTool` now forward to native `document.modelContext` when it appears. `provideContext` and `clearContext` don't forward because they're destructive replace/clear operations that would clobber site-registered tools in the native store.

Spec context: W3C PR #184 merged May 27, 2026. Chrome 150 deprecated `navigator.modelContext`. The native `document.modelContext` has both page-side methods (`registerTool`, `unregisterTool`) and agent-side methods (`getTools`, `executeTool`, `ontoolchange`).

Testing: `pnpm run check` passes (typecheck, lint, 511 tests). Added 15 tests covering the new bridge behavior and polyfill forwarding. All pre-existing tests still pass.