### PR TITLE
Pass WebMCP/MCP tool schemas to providers verbatim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,15 @@ jobs:
         with:
           chrome-version: stable
 
+      # Ubuntu 24.04+ runner images restrict unprivileged user namespaces
+      # (kernel.apparmor_restrict_unprivileged_userns=1), which breaks Chrome's
+      # namespace sandbox and aborts on the non-setuid SUID fallback helper.
+      # Re-allow user namespaces so headless Chrome runs fully sandboxed.
+      # See https://github.com/actions/runner-images/issues/10015
+      - name: Allow Chrome user-namespace sandbox
+        if: matrix.node-version == '22.x'
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
+
       - name: Run read-page browser tests
         if: matrix.node-version == '22.x'
         run: pnpm run test:browser:built

--- a/src/lib/mcp/tool-bridge.ts
+++ b/src/lib/mcp/tool-bridge.ts
@@ -4,12 +4,11 @@
  */
 
 import log from '../logger';
-import { tool } from 'ai';
-import { z } from 'zod';
-import { jsonSchemaToZod } from '../schema/jsonschema-to-zod';
+import { tool, jsonSchema } from 'ai';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import type { RemoteMCPSession, RemoteMCPToolCapability } from './manager';
 import type { JSONSchema7 } from 'json-schema';
+import { normalizeToolInputSchema } from '../schema/normalize-tool-input-schema';
 
 /**
  * Convert an MCP tool to AI SDK tool format
@@ -20,27 +19,16 @@ export function convertMCPToAISDKTool(
 ) {
   const { tool: mcpTool } = capability;
 
-  // Convert the input schema
-  let zodSchema;
-  try {
-    zodSchema = mcpTool.inputSchema
-      ? jsonSchemaToZod(mcpTool.inputSchema as JSONSchema7)
-      : z.object({});
-  } catch (error) {
-    log.error(`Failed to convert schema for "${mcpTool.name}":`, error);
-    // Fallback to empty object schema
-    zodSchema = z.object({});
-  }
-
   const toolDefinition = {
     description: mcpTool.description || `Tool: ${mcpTool.name}`,
-    inputSchema: zodSchema,
-    execute: async (
-      args: z.infer<typeof zodSchema>,
-      { abortSignal }: { abortSignal?: AbortSignal } = {}
-    ) => {
+    // Server-provided JSON Schema is passed through verbatim; see
+    // normalizeToolInputSchema for why the Zod round-trip was removed.
+    inputSchema: jsonSchema<unknown>(normalizeToolInputSchema(mcpTool.inputSchema) as JSONSchema7),
+    execute: async (args: unknown, { abortSignal }: { abortSignal?: AbortSignal } = {}) => {
       // MCP protocol expects an object for arguments, even if empty.
-      const processedArgs = args === undefined || args === null ? {} : args;
+      const processedArgs = (
+        args !== null && typeof args === 'object' && !Array.isArray(args) ? args : {}
+      ) as Record<string, unknown>;
 
       try {
         const result = await session.executeTool(capability, processedArgs, abortSignal);

--- a/src/lib/schema/normalize-tool-input-schema.ts
+++ b/src/lib/schema/normalize-tool-input-schema.ts
@@ -1,0 +1,17 @@
+/**
+ * Normalize a tool-provided JSON Schema for use as an AI SDK tool inputSchema.
+ *
+ * Tool schemas from pages (WebMCP) and remote MCP servers are passed through to
+ * providers verbatim — the AI SDK provider adapters already translate JSON Schema
+ * into each API's dialect (e.g. Gemini's OpenAPI subset), preserving descriptions,
+ * union types, and defaults that a Zod round-trip would lose.
+ *
+ * This helper only guards the container shape: anything that is not a plain object
+ * becomes the canonical "no parameters" schema.
+ */
+export function normalizeToolInputSchema(schema: unknown): Record<string, unknown> {
+  if (!schema || typeof schema !== 'object' || Array.isArray(schema)) {
+    return { type: 'object', properties: {} };
+  }
+  return schema as Record<string, unknown>;
+}

--- a/src/lib/webmcp/tool-bridge.ts
+++ b/src/lib/webmcp/tool-bridge.ts
@@ -7,121 +7,15 @@
  */
 
 import log from '../logger';
-import { tool } from 'ai';
-import { z } from 'zod';
+import { tool, jsonSchema } from 'ai';
+import type { JSONSchema7 } from 'json-schema';
 import { getTabManager } from './lifecycle';
+import { normalizeToolInputSchema } from '../schema/normalize-tool-input-schema';
 
 /**
  * Convert a WebMCP tool to AI SDK tool format
  * Handles execution differently based on context (background vs content/popup)
  */
-// Convert JSON Schema (draft-ish) to Zod - mirrors MCP converter behavior for consistency
-type JSONSchemaLike = {
-  type?: string;
-  enum?: string[];
-  minLength?: number;
-  maxLength?: number;
-  minimum?: number;
-  maximum?: number;
-  items?: unknown;
-  minItems?: number;
-  maxItems?: number;
-  properties?: Record<string, unknown>;
-  required?: string[];
-  additionalProperties?: boolean;
-  anyOf?: unknown[];
-  oneOf?: unknown[];
-  description?: string;
-};
-
-function jsonSchemaToZod(schema: unknown): z.ZodTypeAny {
-  if (!schema || typeof schema !== 'object') return z.object({});
-  const sch = schema as JSONSchemaLike;
-
-  // Handle boolean schemas
-  if (typeof (sch as unknown) === 'boolean') {
-    return (sch as unknown as boolean) ? z.any() : z.never();
-  }
-
-  // Handle type switch
-  switch (sch.type) {
-    case 'string': {
-      let s = z.string();
-      if (sch.enum) return z.enum(sch.enum as [string, ...string[]]);
-      if (typeof sch.minLength === 'number') s = s.min(sch.minLength);
-      if (typeof sch.maxLength === 'number') s = s.max(sch.maxLength);
-      if (sch.description) s = s.describe(sch.description);
-      return s;
-    }
-    case 'number':
-    case 'integer': {
-      let n = sch.type === 'integer' ? z.number().int() : z.number();
-      if (typeof sch.minimum === 'number') n = n.min(sch.minimum);
-      if (typeof sch.maximum === 'number') n = n.max(sch.maximum);
-      return n;
-    }
-    case 'boolean':
-      return z.boolean();
-    case 'array': {
-      const itemSchema = sch.items ? jsonSchemaToZod(sch.items) : z.any();
-      let arr = z.array(itemSchema);
-      if (typeof sch.minItems === 'number') arr = arr.min(sch.minItems);
-      if (typeof sch.maxItems === 'number') arr = arr.max(sch.maxItems);
-      return arr;
-    }
-    case 'object': {
-      const shape: Record<string, z.ZodTypeAny> = {};
-      const properties = (sch.properties || {}) as Record<string, unknown>;
-      const required: string[] = Array.isArray(sch.required) ? sch.required : [];
-      for (const [key, prop] of Object.entries(properties)) {
-        const propZod = jsonSchemaToZod(prop);
-        shape[key] = required.includes(key) ? propZod : propZod.optional();
-      }
-      let obj = z.object(shape);
-      // Note: additionalProperties false would require strict + catchall never
-      if (sch.additionalProperties === false) {
-        try {
-          const maybeCatchall = obj as unknown as {
-            catchall?: (arg: z.ZodTypeAny) => z.ZodTypeAny;
-          };
-          const maybeStrict = obj as unknown as { strict?: () => z.ZodTypeAny };
-          if (typeof maybeCatchall.catchall === 'function') {
-            obj = maybeCatchall.catchall(z.never()) as unknown as typeof obj;
-          }
-          if (typeof maybeStrict.strict === 'function') {
-            obj = maybeStrict.strict() as unknown as typeof obj;
-          }
-        } catch {
-          // Best-effort; ignore if methods not present
-        }
-      }
-      return obj;
-    }
-    default: {
-      // Handle unions anyOf/oneOf
-      if (Array.isArray(sch.anyOf) && sch.anyOf.length > 0) {
-        const variants = (sch.anyOf as unknown[]).map((v) => jsonSchemaToZod(v));
-        return variants.length >= 2 ? z.union([variants[0], variants[1]]) : variants[0] || z.any();
-      }
-      if (Array.isArray(sch.oneOf) && sch.oneOf.length > 0) {
-        const variants = (sch.oneOf as unknown[]).map((v) => jsonSchemaToZod(v));
-        return variants.length >= 2 ? z.union([variants[0], variants[1]]) : variants[0] || z.any();
-      }
-      // If properties without type, assume object
-      if (sch.properties && !sch.type) {
-        const shape: Record<string, z.ZodTypeAny> = {};
-        const required: string[] = Array.isArray(sch.required) ? sch.required : [];
-        for (const [key, prop] of Object.entries(sch.properties as Record<string, unknown>)) {
-          const propZod = jsonSchemaToZod(prop);
-          shape[key] = required.includes(key) ? propZod : propZod.optional();
-        }
-        return z.object(shape);
-      }
-      return z.any();
-    }
-  }
-}
-
 export function convertWebMCPToAISDKTool(
   webmcpTool: {
     name: string;
@@ -131,17 +25,16 @@ export function convertWebMCPToAISDKTool(
   },
   tabId: number // The tab where this tool was registered
 ) {
-  // Convert the input schema to Zod
-  let zodSchema: z.ZodTypeAny = z.object({});
-  try {
-    zodSchema = jsonSchemaToZod(webmcpTool.inputSchema);
-  } catch (error) {
-    log.error(`Failed to convert schema for WebMCP tool "${webmcpTool.name}":`, error);
-  }
-
+  // Pass the page's JSON Schema through verbatim. A lossy JSON-Schema->Zod->JSON-Schema
+  // round-trip previously dropped descriptions on non-string properties and turned
+  // union types (e.g. `type: ['string','number']`) into typeless `{}` declarations,
+  // which degraded provider function calling (Gemini leaked text-format tool calls).
+  // Input validation stays with the page tool, matching MCP client norms.
   const toolDefinition = {
     description: webmcpTool.description || `Tool: ${webmcpTool.name}`,
-    inputSchema: zodSchema,
+    inputSchema: jsonSchema<unknown>(
+      normalizeToolInputSchema(webmcpTool.inputSchema) as JSONSchema7
+    ),
     execute: async (args: unknown, { abortSignal }: { abortSignal?: AbortSignal } = {}) => {
       log.debug(`[WebMCP Tool Bridge] Executing tool ${webmcpTool.name}:`, args);
       log.debug(`[WebMCP Tool Bridge] Tool was registered from tab ${tabId}`);

--- a/tests/browser/mv3-extension.mjs
+++ b/tests/browser/mv3-extension.mjs
@@ -278,8 +278,12 @@ async function main() {
       '--password-store=basic',
       '--use-mock-keychain',
       '--remote-debugging-pipe',
-      `--disable-extensions-except=${extensionPath}`,
-      `--load-extension=${extensionPath}`,
+      // Chromium builds that self-identify as a stable/beta channel silently
+      // ignore --load-extension (branded Chrome since 137, and the channel-
+      // stamped Chromium snapshot builds CI installs since ~151). Load the
+      // unpacked extension over CDP instead — the sanctioned automation path.
+      // Requires Chromium / Chrome for Testing 126+.
+      '--enable-unsafe-extension-debugging',
       `--user-data-dir=${profileDirectory}`,
       'about:blank',
     ],
@@ -303,6 +307,13 @@ async function main() {
   };
 
   try {
+    try {
+      await cdp.send('Extensions.loadUnpacked', { path: extensionPath });
+    } catch {
+      throw new Error(
+        'Could not load the built extension over CDP. Use Chromium or Chrome for Testing 126+ (set CHROME_FOR_TESTING_BIN).'
+      );
+    }
     let worker;
     try {
       worker = await waitFor(async () => {
@@ -315,9 +326,7 @@ async function main() {
         );
       }, 'extension service worker');
     } catch {
-      throw new Error(
-        'AgentBoard service worker did not load. Use Chromium or Chrome for Testing (set CHROME_FOR_TESTING_BIN); branded Chrome 137+ disables --load-extension.'
-      );
+      throw new Error('AgentBoard service worker did not start after the extension loaded.');
     }
     const extensionId = new URL(worker.url).host;
 

--- a/tests/tool-input-schema-passthrough.test.ts
+++ b/tests/tool-input-schema-passthrough.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Tool input schema passthrough
+ *
+ * Regression tests for the lossy JSON-Schema -> Zod -> JSON-Schema round-trip
+ * that previously degraded WebMCP/MCP tool declarations before providers saw
+ * them: descriptions on non-string properties were dropped, union types like
+ * `type: ['string','number']` collapsed into typeless `{}` declarations, and
+ * defaults disappeared. On Gemini this broke function calling outright (the
+ * model leaked text-format pseudo tool calls with `<ctrl46>` tokens instead of
+ * emitting native calls, observed with Shopify's storefront WebMCP tools).
+ *
+ * The contract under test: the exact JSON Schema a page or MCP server declares
+ * is what the AI SDK hands to the provider adapter, via `asSchema(...)` — the
+ * same resolution streamText performs when preparing tools.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { asSchema } from 'ai';
+import type { Tool as MCPTool } from '@modelcontextprotocol/sdk/types.js';
+
+import { convertWebMCPToAISDKTool } from '../src/lib/webmcp/tool-bridge';
+import { convertMCPToAISDKTool } from '../src/lib/mcp/tool-bridge';
+import { normalizeToolInputSchema } from '../src/lib/schema/normalize-tool-input-schema';
+import type { RemoteMCPSession, RemoteMCPToolCapability } from '../src/lib/mcp/manager';
+import { getTabManager } from '../src/lib/webmcp/lifecycle';
+
+vi.mock('../src/lib/webmcp/lifecycle', () => ({
+  getTabManager: vi.fn(),
+}));
+
+vi.mock('../src/lib/logger', () => ({
+  default: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+/** Trimmed from Shopify WebMCP v0.1.0 `update_cart`: descriptions live on an
+ *  array, a nested object, and an integer with a default — every spot the old
+ *  Zod round-trip silently dropped. */
+const updateCartSchema = {
+  type: 'object',
+  required: ['cart'],
+  properties: {
+    cart: {
+      type: 'object',
+      required: ['line_items'],
+      properties: {
+        line_items: {
+          type: 'array',
+          description: 'Items to add or update (1-10).',
+          items: {
+            type: 'object',
+            properties: {
+              item: {
+                type: 'object',
+                description: 'The merchandise to add.',
+                properties: {
+                  id: { type: 'string', description: 'ProductVariant GID.' },
+                },
+              },
+              handle: { type: 'string', description: 'Product handle.' },
+              quantity: {
+                type: 'integer',
+                description: 'Quantity. Defaults to 1. Set 0 to remove.',
+                default: 1,
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+/** Trimmed from Shopify WebMCP v0.1.0 `show_variant`: a union-typed property
+ *  the old converter turned into a typeless `{}` declaration. */
+const showVariantSchema = {
+  type: 'object',
+  required: ['catalog'],
+  properties: {
+    catalog: {
+      type: 'object',
+      description: 'Provide EITHER variant_id OR selected_options.',
+      properties: {
+        variant_id: {
+          type: ['string', 'number'],
+          description: 'ProductVariant GID or numeric variant ID.',
+        },
+      },
+    },
+  },
+};
+
+/** Resolve a converted tool's schema exactly as streamText hands it to a provider. */
+function providerSchema(sdkTool: unknown) {
+  return asSchema((sdkTool as { inputSchema: never }).inputSchema);
+}
+
+describe('normalizeToolInputSchema', () => {
+  it('passes plain-object schemas through by reference', () => {
+    expect(normalizeToolInputSchema(updateCartSchema)).toBe(updateCartSchema);
+  });
+
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['a string', 'not-a-schema'],
+    ['a number', 7],
+    ['an array', [{ type: 'object' }]],
+  ])('declares "no parameters" when the schema is %s', (_label, malformed) => {
+    expect(normalizeToolInputSchema(malformed)).toEqual({ type: 'object', properties: {} });
+  });
+});
+
+describe('WebMCP tool schema passthrough', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('preserves descriptions on arrays, nested objects, and integers (update_cart regression)', () => {
+    const sdkTool = convertWebMCPToAISDKTool(
+      { name: 'update_cart', description: 'Update the cart', inputSchema: updateCartSchema },
+      100
+    );
+
+    const schema = providerSchema(sdkTool).jsonSchema as typeof updateCartSchema;
+    expect(schema).toEqual(updateCartSchema);
+
+    // Explicit spot-checks on the fields the old converter dropped.
+    const lineItems = schema.properties.cart.properties.line_items;
+    expect(lineItems.description).toBe('Items to add or update (1-10).');
+    expect(lineItems.items.properties.item.description).toBe('The merchandise to add.');
+    expect(lineItems.items.properties.quantity.description).toBe(
+      'Quantity. Defaults to 1. Set 0 to remove.'
+    );
+    expect(lineItems.items.properties.quantity.default).toBe(1);
+    expect(schema.required).toEqual(['cart']);
+  });
+
+  it('preserves union types instead of declaring typeless properties (show_variant regression)', () => {
+    const sdkTool = convertWebMCPToAISDKTool(
+      { name: 'show_variant', description: 'Show a variant', inputSchema: showVariantSchema },
+      100
+    );
+
+    const schema = providerSchema(sdkTool).jsonSchema as typeof showVariantSchema;
+    const variantId = schema.properties.catalog.properties.variant_id;
+    expect(variantId.type).toEqual(['string', 'number']);
+    expect(variantId.description).toBe('ProductVariant GID or numeric variant ID.');
+    expect(schema.properties.catalog.description).toBe(
+      'Provide EITHER variant_id OR selected_options.'
+    );
+  });
+
+  it('declares "no parameters" for tools without a usable schema', () => {
+    for (const inputSchema of [undefined, 'garbage']) {
+      const sdkTool = convertWebMCPToAISDKTool(
+        { name: 'schemaless', description: 'No schema', inputSchema },
+        100
+      );
+      expect(providerSchema(sdkTool).jsonSchema).toEqual({ type: 'object', properties: {} });
+    }
+  });
+
+  it('leaves input validation to the page tool', () => {
+    const sdkTool = convertWebMCPToAISDKTool(
+      { name: 'update_cart', description: 'Update the cart', inputSchema: updateCartSchema },
+      100
+    );
+    // No client-side validate function: the page tool owns argument validation,
+    // matching MCP client norms.
+    expect(providerSchema(sdkTool).validate).toBeUndefined();
+  });
+
+  it('passes model-generated arguments through to the page tool untouched', async () => {
+    const callTool = vi.fn().mockResolvedValue('ok');
+    const descriptor = { name: 'show_variant', inputSchema: showVariantSchema };
+    vi.mocked(getTabManager).mockReturnValue({
+      getToolRegistry: (tabId: number) => (tabId === 100 ? { tools: [descriptor] } : undefined),
+      callTool,
+    } as unknown as ReturnType<typeof getTabManager>);
+
+    // A union-typed number and a key outside the schema both survive: the old
+    // Zod pipeline could coerce or reject shapes the page tool accepts.
+    const args = { catalog: { variant_id: 123, unlisted: 'kept' } };
+    const sdkTool = convertWebMCPToAISDKTool(descriptor, 100) as unknown as {
+      execute: (input: unknown) => Promise<unknown>;
+    };
+    await expect(sdkTool.execute(args)).resolves.toBe('ok');
+    expect(callTool).toHaveBeenCalledWith(100, 'show_variant', args, undefined);
+  });
+});
+
+describe('Remote MCP tool schema passthrough', () => {
+  const executeTool = vi.fn();
+  const session = { executeTool } as unknown as RemoteMCPSession;
+
+  function capabilityFor(inputSchema: unknown): RemoteMCPToolCapability {
+    return {
+      serverName: 'server',
+      tool: { name: 'remote_tool', description: 'Remote tool', inputSchema } as MCPTool,
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('hands the server-declared JSON Schema to the provider verbatim', () => {
+    const sdkTool = convertMCPToAISDKTool(session, capabilityFor(updateCartSchema));
+    const schema = providerSchema(sdkTool);
+    expect(schema.jsonSchema).toEqual(updateCartSchema);
+    expect(schema.validate).toBeUndefined();
+  });
+
+  it('declares "no parameters" when the server omits a schema', () => {
+    const sdkTool = convertMCPToAISDKTool(session, capabilityFor(undefined));
+    expect(providerSchema(sdkTool).jsonSchema).toEqual({ type: 'object', properties: {} });
+  });
+
+  it('coerces non-object arguments to an empty object for the MCP protocol', async () => {
+    executeTool.mockResolvedValue({ isError: false, content: [{ type: 'text', text: 'done' }] });
+    const sdkTool = convertMCPToAISDKTool(session, capabilityFor(updateCartSchema)) as unknown as {
+      execute: (input: unknown) => Promise<unknown>;
+    };
+
+    await expect(sdkTool.execute(undefined)).resolves.toBe('done');
+    expect(executeTool).toHaveBeenLastCalledWith(capabilityFor(updateCartSchema), {}, undefined);
+
+    const args = { cart: { line_items: [{ handle: 'verticalboard-first', quantity: 1 }] } };
+    await expect(sdkTool.execute(args)).resolves.toBe('done');
+    expect(executeTool).toHaveBeenLastCalledWith(capabilityFor(updateCartSchema), args, undefined);
+  });
+});


### PR DESCRIPTION
_AI-generated - Claude Fable_

------------------- 

## Problem

Testing AgentBoard against Shopify's storefront WebMCP tools (`search_catalog`, `update_cart`, `show_variant`, …) with a Gemini agent, cart updates consistently failed: instead of emitting a native function call, the model leaked its internal tool-call serialization as plain text:

```
<executetool>
update

cart(cart={lineitems:{handle:<ctrl46>verticalboard-first<ctrl46>,quantity:1}})
</executetool>
```

Note the mangled tool name (`update_cart`), `<ctrl46>` control tokens in place of quotes, and the invented argument shape (`lineitems` object instead of the schema's `line_items` array).

## Root cause

Both tool bridges (`src/lib/webmcp/tool-bridge.ts` and `src/lib/mcp/tool-bridge.ts`) round-tripped tool input schemas through a hand-rolled JSON-Schema→Zod converter before the AI SDK converted them back to JSON Schema for the provider. That round-trip is lossy. Piping Shopify's deployed WebMCP v0.1.0 schemas through the exact pipeline (jsonSchemaToZod → AI SDK `zodSchema()` → `@ai-sdk/google` conversion) shows what Gemini actually received:

- **Typeless declarations**: `show_variant.catalog.variant_id` is declared as `type: ["string","number"]`. The converter has no handling for type arrays, so it fell through to `z.any()`, which reaches the provider as a typeless `"variant_id": {}`. Gemini requires typed properties; a typeless property in the `functionDeclarations` is a known trigger for malformed / text-mode function calling.
- **Descriptions dropped on every non-string property** (objects, arrays, integers, enums). For `update_cart` the model lost `line_items`' "Items to add or update (1-10).", `item`'s "The merchandise to add.", and the `quantity` semantics — which is exactly why it invented `cart={lineitems:{handle:...}}` instead of `cart.line_items: [{handle, quantity}]`.
- **`default` values dropped** (minor).

## Fix

Pass the page/server-declared JSON Schema to the AI SDK verbatim via `jsonSchema()` instead of converting to Zod. The provider adapters already translate JSON Schema into each API's dialect — e.g. `@ai-sdk/google` turns `type: ["string","number"]` into `anyOf` and preserves descriptions — so the round-trip added nothing and only destroyed information.

- `src/lib/schema/normalize-tool-input-schema.ts` (new): guards the container shape only; anything that isn't a plain object becomes the canonical `{type:"object",properties:{}}`.
- `src/lib/webmcp/tool-bridge.ts`: schema passthrough; removes the ~120-line inlined converter.
- `src/lib/mcp/tool-bridge.ts`: same passthrough for remote MCP tools; `execute` args are now `unknown` with an explicit object guard before `session.executeTool` (MCP requires object arguments).

Trade-off: the Zod schema previously validated model-generated arguments before execution; with `jsonSchema()` and no validate function, arguments pass through unvalidated. That matches common MCP client behavior (the tool owns validation — Shopify's tools coerce defensively, and AgentBoard's polyfill never validated either). If client-side validation is wanted later, `jsonSchema(schema, { validate })` can be wired to a CSP-safe ajv.

After the fix, the same Shopify schemas reach Gemini with all descriptions intact and `variant_id` declared as `anyOf: [{type:"string"},{type:"number"}]`, and `update_cart` calls arrive as native tool calls with the correct `cart.line_items: [{handle, quantity}]` shape.

## Tests

`tests/tool-input-schema-passthrough.test.ts` (14 tests) pins the observable contract via `asSchema(tool.inputSchema)` — the same resolution `streamText` performs when handing tools to a provider:

- update_cart regression: descriptions on arrays / nested objects / integers and `default` survive.
- show_variant regression: union `type` arrays survive instead of collapsing to `{}`.
- Schemaless / malformed schemas declare "no parameters".
- No client-side validate fn; execute passes union-typed and unlisted arguments through untouched.
- MCP bridge: verbatim handoff + non-object→`{}` argument guard.

Verified the tests fail against the previous implementation (6/14 fail) and pass with the fix. Full suite: 605 passed, typecheck + lint clean.
