### PR TITLE
Document optional Parallel Search MCP configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ Bring custom external tools to give your agent superpowers. AgentBoard supports 
 
 The agent can call any remote MCP server, as long as it supports HTTP streaming. Bring your MCP config and agent will do the rest to discover and expose available tools. Run `/tools` in chat to audit available capabilities.
 
+The optional `parallel-search` entry below uses Parallel Search MCP for web search and fetching requested URLs. Its hosted endpoint requires no account or API key. Add it only if you explicitly opt in: when you invoke its tools, user-provided search objectives, search queries, and requested URLs are sent to Parallel.
+
 ```json
 {
   "mcpServers": {
@@ -123,6 +125,10 @@ The agent can call any remote MCP server, as long as it supports HTTP streaming.
       "url": "https://internal.example.com/mcp",
       "transport": "http",
       "authToken": "your-bearer-token"
+    },
+    "parallel-search": {
+      "url": "https://search.parallel.ai/mcp",
+      "transport": "http"
     }
   }
 }


### PR DESCRIPTION
## Why

AgentBoard users can explicitly opt in to add hosted web search and URL-fetching tools through the existing Remote MCP Servers configuration. The hosted endpoint requires no account or API key.

## Changes

- Add an optional `parallel-search` sibling using the required HTTP transport and canonical hosted endpoint.
- Preserve the existing GitHub and authenticated company-tools examples, including their tokens and user-controlled configuration; no provider or server becomes a default.
- State that users must explicitly opt in and that user-provided search objectives, search queries, and requested URLs are sent to Parallel when its tools are invoked.

## Validation

- `git diff --check`: passed.

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.